### PR TITLE
Add radanalytics.io spark-operator

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -57,6 +57,16 @@ spec:
         name: manifests
         path: grafana/cluster
     name: grafana-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: radanalyticsio/spark/cluster
+    name: radanalyticsio-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: radanalyticsio/spark/operator
+    name: radanalyticsio-spark-operator
   repos:
   - name: manifests
     uri: https://github.com/opendatahub-io/odh-manifests/tarball/v0.7-branch-openshift

--- a/radanalyticsio/spark/cluster/base/clusterrole.yaml
+++ b/radanalyticsio/spark/cluster/base/clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spark-operator
+rules:
+- apiGroups:
+  - radanalytics.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - replicationcontrollers
+  - services
+  - configmaps
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - update
+  - watch
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/radanalyticsio/spark/cluster/base/clusterrolebinding.yaml
+++ b/radanalyticsio/spark/cluster/base/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: spark-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: spark-operator
+subjects:
+  - kind: ServiceAccount
+    name: spark-operator
+    namespace: opendatahub

--- a/radanalyticsio/spark/cluster/base/kustomization.yaml
+++ b/radanalyticsio/spark/cluster/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- sparkapplications.radanalytics.io.crd.yaml
+- sparkclusters.radanalytics.io.crd.yaml
+- sparkhistoryservers.radanalytics.io.crd.yaml
+- service-account.yaml
+- clusterrole.yaml
+- clusterrolebinding.yaml
+namespace: opendatahub

--- a/radanalyticsio/spark/cluster/base/service-account.yaml
+++ b/radanalyticsio/spark/cluster/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: spark-operator

--- a/radanalyticsio/spark/cluster/base/sparkapplications.radanalytics.io.crd.yaml
+++ b/radanalyticsio/spark/cluster/base/sparkapplications.radanalytics.io.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sparkapplications.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkApplication
+    listKind: SparkApplicationList
+    plural: sparkapplications
+    singular: sparkapplication
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1

--- a/radanalyticsio/spark/cluster/base/sparkclusters.radanalytics.io.crd.yaml
+++ b/radanalyticsio/spark/cluster/base/sparkclusters.radanalytics.io.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sparkclusters.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkCluster
+    listKind: SparkClusterList
+    plural: sparkclusters
+    singular: sparkcluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1

--- a/radanalyticsio/spark/cluster/base/sparkhistoryservers.radanalytics.io.crd.yaml
+++ b/radanalyticsio/spark/cluster/base/sparkhistoryservers.radanalytics.io.crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: sparkhistoryservers.radanalytics.io
+spec:
+  group: radanalytics.io
+  names:
+    kind: SparkHistoryServer
+    listKind: SparkHistoryServerList
+    plural: sparkhistoryservers
+    singular: sparkhistoryserver
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1

--- a/radanalyticsio/spark/operator/base/deployment.yaml
+++ b/radanalyticsio/spark/operator/base/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spark-operator
+  labels: &default-labels
+    app.kubernetes.io/name: spark-operator
+    app.kubernetes.io/version: v1.0.7-v1
+spec:
+  replicas: 1
+  selector:
+    matchLabels: *default-labels
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels: *default-labels
+    spec:
+      serviceAccountName: spark-operator
+      containers:
+      - name: spark-operator
+        image: quay.io/radanalyticsio/spark-operator:1.0.7
+        env:
+        #- name: WATCH_NAMESPACE
+        #  value: "~"
+        - name: CRD
+          value: "true"
+        - name: FULL_RECONCILIATION_INTERVAL_S
+          value: "180"
+        - name: METRICS
+          value: "true"
+        - name: METRICS_PORT
+          value: "8080"
+        - name: METRICS_JVM
+          value: "false"
+        - name: COLORS
+          value: "false"
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "512Mi"
+            cpu: "1000m"
+        imagePullPolicy: Always
+

--- a/radanalyticsio/spark/operator/base/kustomization.yaml
+++ b/radanalyticsio/spark/operator/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+namespace: opendatahub
+images:
+- name: quay.io/radanalyticsio/spark-operator
+  newTag: 1.0.7
+  newName: quay.io/radanalyticsio/spark-operator


### PR DESCRIPTION
Deploys version 1.0.7 of the radanalytics spark-operator. 

You can test the deployment by attempting to create a `SparkApplication` or `SparkCluster` custom resource

```yaml
apiVersion: radanalytics.io/v1
kind: SparkApplication
metadata:
  name: my-cluster
spec:
  mainApplicationFile: local:///opt/spark/examples/jars/spark-examples_2.11-2.3.0.jar
  mainClass: org.apache.spark.examples.SparkPi
```

```yaml
apiVersion: radanalytics.io/v1
kind: SparkCluster
metadata:
  name: my-cluster
spec:
  worker:
    instances: "1"
```