### PR TITLE
Parameterize namespace in Spark clusterrolebinding

### DIFF
--- a/radanalyticsio/spark/cluster/base/clusterrolebinding.yaml
+++ b/radanalyticsio/spark/cluster/base/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: spark-operator
-    namespace: opendatahub
+    namespace: $(namespace)

--- a/radanalyticsio/spark/cluster/base/kustomization.yaml
+++ b/radanalyticsio/spark/cluster/base/kustomization.yaml
@@ -8,3 +8,15 @@ resources:
 - clusterrole.yaml
 - clusterrolebinding.yaml
 namespace: opendatahub
+
+vars:
+- name: namespace
+  objref:
+    kind: ServiceAccount
+    name: spark-operator
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+
+configurations:
+- params.yaml

--- a/radanalyticsio/spark/cluster/base/params.yaml
+++ b/radanalyticsio/spark/cluster/base/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+- path: subjects/namespace
+  kind: ClusterRoleBinding
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Add `namespace` parameter to ClusterRoleBinding so that SparkOperator work in namespaces other than `opendatahub`

Closes #21 