### PR TITLE
Update JupyterHub resources to follow new structure of singleuser-profiles config

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
@@ -11,7 +11,7 @@ spec:
       openshift.io/imported-from: quay.io/odh-jupyterhub/jupyterhub-img
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/jupyterhub-img:latest
+      name: quay.io/odh-jupyterhub/jupyterhub-img:3.0.7-592bb9
     name: latest
     referencePolicy:
       type: Source

--- a/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
@@ -20,6 +20,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - pods
+  - services
   verbs:
   - create
   - delete
@@ -33,6 +34,7 @@ rules:
   - events
   - persistentvolumeclaims
   - pods
+  - services
   verbs:
   - get
   - list

--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -7,49 +7,76 @@ data:
       profiles:
       - name: globals
         env:
-          S3_ENDPOINT_URL: $(s3_endpoint_url)
+          - name: S3_ENDPOINT_URL
+            value: $(s3_endpoint_url)
         resources:
-          mem_limit: 2Gi
-          cpu_limit: 1
+          requests:
+            memory: 1Gi
+            cpu: 500m
+          limits:
+            memory: 2Gi
+            cpu: 1
 
       - name: Spark Notebook
         images:
         - 's2i-spark-minimal-notebook:3.6'
         - 's2i-spark-scipy-notebook:3.6'
+        - 's2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3'
         env:
-          PYSPARK_SUBMIT_ARGS: '--conf spark.cores.max=6 --conf spark.executor.instances=2 --conf spark.executor.memory=3G --conf spark.executor.cores=3 --conf spark.driver.memory=4G --packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell'
-          PYSPARK_DRIVER_PYTHON: 'jupyter'
-          PYSPARK_DRIVER_PYTHON_OPTS: 'notebook'
-          SPARK_HOME: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
-          PYTHONPATH: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
+          - name: PYSPARK_SUBMIT_ARGS
+            value: '--conf spark.cores.max=2 --conf spark.executor.instances=2 --conf spark.executor.memory=1G --conf spark.executor.cores=1 --conf spark.driver.memory=2G --packages com.amazonaws:aws-java-sdk:1.7.4,org.apache.hadoop:hadoop-aws:2.7.3 pyspark-shell'
+          - name: PYSPARK_DRIVER_PYTHON
+            value: 'jupyter'
+          - name: PYSPARK_DRIVER_PYTHON_OPTS
+            value: 'notebook'
+          - name: SPARK_HOME
+            value: '/opt/app-root/lib/python3.6/site-packages/pyspark/'
+          - name: PYTHONPATH
+            value: '$PYTHONPATH:/opt/app-root/lib/python3.6/site-packages/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/:/opt/app-root/lib/python3.6/site-packages/pyspark/python/lib/py4j-0.8.2.1-src.zip'
         services:
           spark:
-            template: 'jupyterhub-spark-operator-configmap'
-            parameters:
-              WORKER_NODES: '2'
-              MASTER_NODES: '1'
-              MASTER_MEMORY_LIMIT: '2Gi'
-              MASTER_CPU_LIMIT: '1'
-              MASTER_MEMORY_REQUEST: '2Gi'
-              MASTER_CPU_REQUEST: '1'
-              WORKER_MEMORY_LIMIT: '2Gi'
-              WORKER_CPU_LIMIT: '1'
-              WORKER_MEMORY_REQUEST: '2Gi'
-              WORKER_CPU_REQUEST: '1'
-              SPARK_IMAGE: 'quay.io/opendatahub/spark-cluster-image:spark22python36'
+            resources:
+            - name: spark-cluster-template
+              path: notebookPodServiceTemplate
+            - name: spark-cluster-template
+              path: sparkClusterTemplate
+            configuration:
+              worker_nodes: '2'
+              master_nodes: '1'
+              master_memory_limit: '2Gi'
+              master_cpu_limit: '1'
+              master_memory_request: '2Gi'
+              master_cpu_request: '1'
+              worker_memory_limit: '2Gi'
+              worker_cpu_limit: '1'
+              worker_memory_request: '2Gi'
+              worker_cpu_request: '1'
+              spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
             return:
               SPARK_CLUSTER: 'metadata.name'
 
       sizes:
       - name: Small
         resources:
-          mem_limit: 2Gi
-          cpu_limit: 2
+          requests:
+            memory: 1Gi
+            cpu: 1
+          limits:
+            memory: 2Gi
+            cpu: 2
       - name: Medium
         resources:
-          mem_limit: 4Gi
-          cpu_limit: 4
+          requests:
+            memory: 2Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 4
       - name: Large
         resources:
-          mem_limit: 8Gi
-          cpu_limit: 8
+          requests:
+            memory: 4Gi
+            cpu: 4
+          limits:
+            memory: 8Gi
+            cpu: 8

--- a/jupyterhub/jupyterhub/base/jupyterhub-spark-operator-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-spark-operator-configmap.yaml
@@ -1,57 +1,41 @@
-apiVersion: template.openshift.io/v1
-kind: Template
+kind: ConfigMap
+apiVersion: v1
 metadata:
-  name: jupyterhub-spark-operator-configmap
-  labels:
-    app: jupyterhub
-    component: spark-operator
-objects:
-- apiVersion: v1
-  data:
-    config: |-
+  name: spark-cluster-template
+data:
+  notebookPodServiceTemplate: |
+    apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+      name: "jupyterhub-nb-{{ user }}"
+    spec:
+      clusterIP: None
+      selector:
+        jupyterhub.opendatahub.io/user: "{{ user }}"
+      sessionAffinity: None
+      type: ClusterIP
+    status:
+      loadBalancer: {}
+  sparkClusterTemplate: |
+    kind: SparkCluster
+    apiVersion: radanalytics.io/v1
+    metadata:
+      name: "spark-cluster-{{ user }}"
+    spec:
       worker:
-        instances: ${WORKER_NODES}
-        memoryLimit: ${WORKER_MEMORY_LIMIT}
-        cpuLimit: ${WORKER_CPU_LIMIT}
-        memoryRequest: ${WORKER_MEMORY_REQUEST}
-        cpuRequest: ${WORKER_CPU_REQUEST}
+        instances: "{{ worker_nodes }}"
+        memoryLimit: "{{ worker_memory_limit }}"
+        cpuLimit: "{{ worker_cpu_limit }}"
+        memoryRequest: "{{ worker_memory_request }}"
+        cpuRequest: "{{ worker_cpu_request }}"
       master:
-        instances: ${MASTER_NODES}
-        memoryLimit: ${MASTER_MEMORY_LIMIT}
-        cpuLimit: ${MASTER_CPU_LIMIT}
-        memoryRequest: ${MASTER_MEMORY_REQUEST}
-        cpuRequest: ${MASTER_CPU_REQUEST}
-      customImage: ${SPARK_IMAGE}
+        instances: "{{ master_nodes }}"
+        memoryLimit: "{{ master_memory_limit }}"
+        cpuLimit: "{{ master_cpu_limit }}"
+        memoryRequest: "{{ master_memory_request }}"
+        cpuRequest: "{{ master_cpu_request }}"
+      customImage: "{{ spark_image }}"
       env:
       - name: SPARK_METRICS_ON
         value: prometheus
-  kind: ConfigMap
-  metadata:
-    labels:
-      radanalytics.io/kind: SparkCluster
-    name: spark-cluster-${USERNAME}
-parameters:
-- name: USERNAME
-  required: true
-- name: WORKER_NODES
-  value: "2"
-- name: MASTER_NODES
-  value: "1"
-- name: MASTER_MEMORY_LIMIT
-  value: 2Gi
-- name: MASTER_CPU_LIMIT
-  value: "2"
-- name: MASTER_MEMORY_REQUEST
-  value: 1Gi
-- name: MASTER_CPU_REQUEST
-  value: "1"
-- name: WORKER_MEMORY_LIMIT
-  value: 2Gi
-- name: WORKER_CPU_LIMIT
-  value: "2"
-- name: WORKER_MEMORY_REQUEST
-  value: 1Gi
-- name: WORKER_CPU_REQUEST
-  value: "1"
-- name: SPARK_IMAGE
-  value: quay.io/radanalyticsio/openshift-spark:2.4-latest

--- a/jupyterhub/jupyterhub/overlays/build/jupyterhub-dh-buildconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/build/jupyterhub-dh-buildconfig.yaml
@@ -21,3 +21,4 @@ spec:
     type: Source
   triggers:
   - type: ConfigChange
+  - type: ImageChange

--- a/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
@@ -1,7 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels: {}
+  labels:
+    opendatahub.io/notebook-image: "true"
   name: s2i-spark-minimal-notebook
 spec:
   lookupPolicy:
@@ -11,7 +12,7 @@ spec:
       openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-spark-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-spark-minimal-notebook:3.6
-    name: "3.6"
+      name: quay.io/odh-jupyterhub/s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3
+    name: "py36-spark2.4.5-hadoop2.7.3"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -1,7 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels: {}
+  labels:
+    opendatahub.io/notebook-image: "true"
   name: s2i-minimal-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
@@ -1,7 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels: {}
+  labels:
+    opendatahub.io/notebook-image: "true"
   name: s2i-scipy-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
@@ -1,7 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels: {}
+  labels:
+    opendatahub.io/notebook-image: "true"
   name: s2i-spark-scipy-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -1,7 +1,8 @@
 apiVersion: image.openshift.io/v1
 kind: ImageStream
 metadata:
-  labels: {}
+  labels:
+    opendatahub.io/notebook-image: "true"
   name: s2i-tensorflow-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/cuda/tensorflow-gpu-notebook.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda/tensorflow-gpu-notebook.yaml
@@ -81,6 +81,7 @@ items:
   metadata:
     labels:
       build: s2i-tensorflow-notebook-gpu
+      opendatahub.io/notebook-image: "true"
     name: s2i-tensorflow-notebook-gpu
   spec:
     lookupPolicy:


### PR DESCRIPTION
This changes couple things to be compatible with latest JupyterHub Singleuser Profiles

* Use k8s way of defining env vars
* Use k8s way of defining resource limits and requests
* Generalize how services are deployed (i.e. enable deployment of SparkCluster resources)

There is one more pending PR on the singleuser profiels repo which needs to be merged, then we update and build a new version of Jupyterhub image and then merge this PR