### PR TITLE
Parameterize namespace in OperatorGroup

### DIFF
--- a/odh-common/base/kustomization.yaml
+++ b/odh-common/base/kustomization.yaml
@@ -7,3 +7,21 @@ namespace: opendatahub
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: odh-common
+
+configMapGenerator:
+- name: odh-common-config
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: odh-common-config
+    apiVersion: v1
+  fieldref:
+    fieldpath: metadata.namespace
+
+configurations:
+- params.yaml

--- a/odh-common/base/operatorgroup.yaml
+++ b/odh-common/base/operatorgroup.yaml
@@ -4,4 +4,4 @@ metadata:
   name: opendatahub
 spec:
   targetNamespaces:
-    - opendatahub
+    - $(namespace)

--- a/odh-common/base/params.env
+++ b/odh-common/base/params.env
@@ -1,0 +1,1 @@
+namespace=opendatahub

--- a/odh-common/base/params.yaml
+++ b/odh-common/base/params.yaml
@@ -1,0 +1,4 @@
+varReference:
+- path: spec/targetNamespaces
+  kind: OperatorGroup
+  apiGroup: operators.coreos.com


### PR DESCRIPTION
Closes #38 

The hardcoded namespaces also prevents Prometheus from starting since the Prometheus operator watches a namespace based on `olm.tagetNamespace` label which was always set to `opendatahub` and operator was failing.