### PR TITLE
Remove explicit namespace configuration from kfdef

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -16,9 +16,6 @@ spec:
         path: ai-library/cluster
     name: ai-library-cluster
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: opendatahub
       repoRef:
         name: manifests
         path: ai-library/operator
@@ -67,17 +64,11 @@ spec:
         path: radanalyticsio/spark/operator
     name: radanalyticsio-spark-operator
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: opendatahub
       repoRef:
         name: manifests
         path: prometheus/cluster
     name: prometheus-cluster
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: opendatahub
       repoRef:
         name: manifests
         path: prometheus/operator
@@ -99,9 +90,6 @@ spec:
         path: jupyterhub/notebook-images
     name: notebook-images
   - kustomizeConfig:
-      parameters:
-      - name: namespace
-        value: opendatahub
       repoRef:
         name: manifests
         path: airflow/operator


### PR DESCRIPTION
I believe this is preventing some of the components to be deployed correctly if deployed to a different namespace than `opendatahub`. 

We should not hardcode namespace unless very specifically necessary (like `istio` or `webhook-manager` in KF)