### PR TITLE
Change kfdef to use apiVersion kfdef.apps.kubeflow.org/v1

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -1,4 +1,4 @@
-apiVersion: kfdef.apps.kubeflow.org/v1beta1
+apiVersion: kfdef.apps.kubeflow.org/v1
 kind: KfDef
 metadata:
   name: opendatahub


### PR DESCRIPTION
Update the default kfctl apiVersion because the operator only watches `kfdef.apps.kubeflow.org/v1`