### PR TITLE
Setting ai library operator image version to tag v0.6

### DIFF
--- a/ai-library/operator/base/kustomization.yaml
+++ b/ai-library/operator/base/kustomization.yaml
@@ -12,6 +12,6 @@ commonLabels:
 images:
 - name: quay.io/opendatahub/ai-library-operator
   newName: quay.io/opendatahub/ai-library-operator
-  digest: sha256:293879aec3cd52959a3b670eaf69bb2ac478847dfc4e498877984e63592f0fb1
+  newTag: v0.6
 generatorOptions:
   disableNameSuffixHash: true

--- a/tests/basictests/ailibrary.sh
+++ b/tests/basictests/ailibrary.sh
@@ -8,10 +8,13 @@ source ${MY_DIR}/../util
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
+OPERATOR_IMAGE="quay.io/opendatahub/ai-library-operator:v0.6"
+
 function test_ai_library() {
     header "Testing AI Library installation"
     os::cmd::expect_success "oc project ${ODHPROJECT}"
     os::cmd::expect_success_and_text "oc get deployment ailibrary-operator" "ailibrary-operator"
+    os::cmd::expect_success_and_text "oc get deployment ailibrary-operator -o jsonpath='{$.spec.template.spec.containers[0].image}'" ${OPERATOR_IMAGE}
     runningpods=($(oc get pods -l name=ailibrary-operator --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
     os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
 }


### PR DESCRIPTION
Before this, we were referring directly to an outdated sha.

To test this change, when you deploy a KfDef that has the ai-library components in it, you should see the ai-library operator running and it should be using the v0.6.

The easy way to see this is to run...

`oc get deployment ailibrary-operator -o jsonpath="{$.spec.template.spec.containers[0].image}"`

The output should be:  
quay.io/opendatahub/ai-library-operator:v0.6

This manual test has also been added to the ailibrary.sh test.

closes #60 