### PR TITLE
Add Makefile for releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,27 @@ REPO_URL="https://github.com/opendatahub-io/odh-manifests"
 KFDEF_FILE="kfdef/kfctl_openshift.yaml"
 COMMIT_MESSAGE="Update KFdef for release $(TAG_NAME)"
 UPDATE_TO_COMMIT=master
+ifndef VERSION
+$(help)
+endif
 
-all: release
+all: help
 
-release: branch tag 
+prep-release: branch tag
+push-release: push-branch push-tag
+
+release: prep-release push-release
+
+help:
+	@echo -e "\
+	This Makefile allows you to create a new release of odh-manifests\n\
+	\n\
+	It requires a variable VERSION in format "MAJOR.MINOR.PATCH" (e.g. VERSION=0.6.1) to be set\n\
+	\n\
+	prep-release\t prepares a version branch (e.g. v0.6-branch) for new release and creates the version tag (e.g. v0.6.1)\n\
+	push-release\t push the version branch and tags\n\
+	\nPlease refer to RELEASE.md for documentation.\
+	"
 
 branch:
 	#Create or update a minor branch (e.g. 0.6.2 -> v0.6-branch)
@@ -29,8 +46,10 @@ update-kfdef-with-tag:
 	sed -i "s#$(REPO_URL).*#$(REPO_URL)/tarball/$(TAG_NAME)#" $(KFDEF_FILE)
 	git add $(KFDEF_FILE)
 	git commit -m $(COMMIT_MESSAGE)
+push-branch:
 	git push --set-upstream origin $(BRANCH_NAME)
 tag: update-kfdef-with-tag
 	echo " => Created tag $(TAG_NAME)"
 	git tag $(TAG_NAME)
+push-tag:
 	git push --tags

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+
+STRIPPED_VERSION=$(shell echo ${VERSION} | sed 's/v*\(.*\)/\1/' )
+MAJOR=$(shell echo ${STRIPPED_VERSION} | sed 's/\..*//' )
+MINOR=$(shell echo ${STRIPPED_VERSION} | sed 's/[^.]*\.\([^.]*\)\..*/\1/' )
+RELEASE=$(shell echo ${STRIPPED_VERSION} | sed 's/.*\.//' )
+BRANCH_NAME=v$(MAJOR).$(MINOR)-branch
+TAG_NAME=v$(MAJOR).$(MINOR).$(RELEASE)
+REPO_URL="https://github.com/opendatahub-io/odh-manifests"
+KFDEF_FILE="kfdef/kfctl_openshift.yaml"
+COMMIT_MESSAGE="Update KFdef for release $(TAG_NAME)"
+UPDATE_TO_COMMIT=master
+
+all: release
+
+release: branch tag 
+
+branch:
+	#Create or update a minor branch (e.g. 0.6.2 -> v0.6-branch)
+	git branch | grep -w $(BRANCH_NAME) ||\
+	( echo " => Creating branch $(BRANCH_NAME)" &&\
+	  git checkout master &&\
+	  git pull &&\
+	  git checkout -b $(BRANCH_NAME) $(UPDATE_TO_COMMIT)) &&\
+	( echo " => Branch $(BRANCH_NAME) exists, rebasing" &&\
+	  git checkout $(BRANCH_NAME) &&\
+	  git rebase $(UPDATE_TO_COMMIT) )
+update-kfdef-with-tag:
+	git checkout $(BRANCH_NAME)
+	sed -i "s#$(REPO_URL).*#$(REPO_URL)/tarball/$(TAG_NAME)#" $(KFDEF_FILE)
+	git add $(KFDEF_FILE)
+	git commit -m $(COMMIT_MESSAGE)
+	git push --set-upstream origin $(BRANCH_NAME)
+tag: update-kfdef-with-tag
+	echo " => Created tag $(TAG_NAME)"
+	git tag $(TAG_NAME)
+	git push --tags

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,41 @@
+# Releasing ODH Manifests
+
+The versioning scheme follows the schemantic versioning (i.e. MAJOR.MINOR.PATCH).
+
+We offer branches based on `MAJOR.MINOR` (e.g. `v0.6-branch`) and tags based on `MAJOR.MINOR.PATCH` (e.g. `v0.6.1`).
+
+## Creating a new MAJOR or MINOR release
+
+To create a new release (tag) and branch you can use the `make` command:
+
+```
+make prep-release VERSION=0.7.0
+```
+
+This will result in the branch `v0.7-branch` to be created and a tag `v0.7.0` created. A manifests repository in the file [kfdef/kfctl_openshift.yaml](kfdef/kfctl_openshift.yaml) will also be updated to point to the newly created tag.
+
+If you are happy with the result, you can push the branch and the tag to the repository
+
+```
+make push-release VERSION=0.7.0
+```
+
+## Creating a new PATCH release
+
+The `PATCH` release is special because it does not result in the new branch created. If the new `PATCH` release is from the top of the `master` branch, the workflow is the same as for `MAJOR` and `MINOR` releases.
+
+In case the `PATCH` release is not directly from the `master` branch (e.g. updating a security issue in an older version), you need to cherry-pick the commits to the release branch (e.g. `v0.5-branch`) and run the following command only to crete the release:
+
+```
+make tag VERSION=0.5.3
+make push-tag VERSION=0.5.3
+```
+
+# Creating a new release from a specific commit
+
+In case you need to use a specific commit below the top of the `master` (and all commits between it and the previous release), you can use the following command:
+
+```
+make prep-release VERSION=0.7.1 UPDATE_TO_COMMIT=<commit-id-below-top-of-master>
+make push-release VERSION=0.7.1
+```


### PR DESCRIPTION
To test this, make sure you are **not in opendatahub-io/odh-manifests** otherwise the `make` run will push new branch and tag to the repo:)

To try this out, run

```
make VERSION=1.2.3
```

It should result in creation of a branch `v1.2-branch` and a tag `v1.2.3` and it also updates the KFDef in the branch and tag to point to the tag

You can see it in my fork:

https://github.com/vpavlin/odh-manifests/releases/tag/v1.2.3
https://github.com/vpavlin/odh-manifests/tree/v1.2-branch

Other use cases that I tried to cover are 

* We do not want to release from the top of the master, but from a specific commit

```
make VERSION=1.3.5 UPDATE_TO_COMMIT=<commit-id-below-top-of-master>
```

* Creating a bugfix release with changes that were cherry-picked to a branch (e.g. v1.5-branch)

```
make tag VERSION=1.5.7
```
