### PR TITLE
Add Makefile, run container as non-root, parameterize

### DIFF
--- a/airflow/operator/manager/manager.yaml
+++ b/airflow/operator/manager/manager.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: controller-manager
-  namespace: system
   labels:
     control-plane: controller-manager
 spec:

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,10 +1,15 @@
 FROM centos:centos8
 
 ARG CHROMEDRIVER_VER=84.0.4147.30
+ARG ORG=opendatahub-io
+ARG BRANCH=master
+
+ENV HOME /root
+WORKDIR /root
 
 RUN dnf install -y bc git go-toolset python3-pip unzip && \
-    git clone https://github.com/crobby/peak && \    
-    cd /peak && \
+    git clone https://github.com/crobby/peak $HOME/peak && \    
+    cd $HOME/peak && \
     git submodule update --init
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
@@ -16,41 +21,43 @@ RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
 RUN curl -o /usr/local/bin/jq http://stedolan.github.io/jq/download/linux64/jq && \
     chmod +x /usr/local/bin/jq
 
-RUN mkdir -p /src && \
-    cd /src && \
-    git clone https://github.com/opendatahub-io/odh-manifests && \
-    chmod -R 777 /src
+RUN mkdir -p $HOME/src && \
+    cd $HOME/src && \
+    git clone --depth=1 --branch ${BRANCH} https://github.com/${ORG}/odh-manifests && \
+    chmod -R 777 $HOME/src
 
-ADD https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz /peak/ 
-RUN tar -C /usr/bin -xvf /peak/oc.tar.gz && \
-    chmod +x /usr/bin/oc
+ADD https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz $HOME/peak/ 
+RUN tar -C /usr/local/bin -xvf $HOME/peak/oc.tar.gz && \
+    chmod +x /usr/local/bin/oc
 
 RUN curl -o /tmp/chromedriver_linux64.zip -L https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VER}/chromedriver_linux64.zip &&\
     unzip /tmp/chromedriver_linux64.zip &&\
     cp chromedriver /usr/local/bin/chromedriver
 
-COPY Pipfile Pipfile.lock /peak
+COPY Pipfile Pipfile.lock $HOME/peak
 
 RUN pip3 install micropipenv &&\
     ln -s `which pip3` /usr/bin/pip &&\
-    cd /peak &&\
+    cd $HOME/peak &&\
     micropipenv install
 
-COPY basictests /peak/operator-tests/odh-manifests/basictests
-COPY resources /peak/operator-tests/odh-manifests/resources
-COPY util /peak/operator-tests/odh-manifests
-COPY setup/kfctl_openshift.yaml /kfdef/
-COPY setup/operatorsetup /peak/
-COPY scripts/install.sh /peak/
-COPY scripts/installandtest.sh /peak/
+COPY basictests $HOME/peak/operator-tests/odh-manifests/basictests
+COPY resources $HOME/peak/operator-tests/odh-manifests/resources
+COPY util $HOME/peak/operator-tests/odh-manifests
+COPY setup/kfctl_openshift.yaml $HOME/kfdef/
+COPY setup/operatorsetup $HOME/peak/
+COPY scripts/install.sh $HOME/peak/
+COPY scripts/installandtest.sh $HOME/peak/
 
-RUN chmod -R 777 /kfdef && \
-    mkdir -p /.kube && \
-    chmod -R 777 /.kube && \
-    chmod -R 777 /peak
+RUN chmod -R 777 $HOME/kfdef && \
+    mkdir -p $HOME/.kube && \
+    chmod -R 777 $HOME/.kube && \
+    chmod -R 777 $HOME/peak && \
+    mkdir -p /peak && \
+    ln -s $HOME/peak/installandtest.sh /peak/installandtest.sh
 
 # For local testing, you can add your own kubeconfig to the image
 # Note:  Do not push the image to a public repo with your kubeconfig
 # ADD kubeconfig /root/.kube/config
 
-CMD /peak/installandtest.sh
+CMD $HOME/peak/installandtest.sh

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,27 @@
+IMAGE=odh-manifests-test
+GIT_ORG=opendatahub-io
+GIT_BRANCH=master
+NAMESPACE=opendatahub
+SKIP_PODS_OUTPUT=
+
+all: test
+test: build run clean
+
+build:
+	podman build -t $(IMAGE) --build-arg ORG=$(GIT_ORG) --build-arg BRANCH=$(GIT_BRANCH) .
+
+run:
+	oc config view --flatten --minify > /tmp/tests-kubeconfig
+	podman run -e SKIP_PODS_OUTPUT=$(SKIP_PODS_OUTPUT) -it -v /tmp/tests-kubeconfig:/tmp/kubeconfig:z $(IMAGE)
+
+clean:
+	oc delete -n $(NAMESPACE) kfdef opendatahub || true
+	oc delete project $(NAMESPACE) || echo -e "\n\n==> If the project deletion failed, you can try to use this script to force it: https://raw.githubusercontent.com/jefferyb/useful-scripts/master/openshift/force-delete-openshift-project\n\n"
+	#Clean up openshift-operators namespace
+	oc get csv -n openshift-operators -o name | grep strimzi-cluster-operator | xargs oc delete -n openshift-operators || true
+	oc get csv -n openshift-operators -o name | grep opendatahub-operator | xargs oc delete -n openshift-operators || true
+	oc delete subscription -n openshift-operators -l peak.test.subscription=opendatahub-operator
+	oc get mutatingwebhookconfiguration -o name | grep seldon | grep $(NAMESPACE) | xargs oc delete || true
+	oc get mutatingwebhookconfiguration -o name | grep katib | grep $(NAMESPACE) | xargs oc delete || true
+	oc get validatingwebhookconfiguration -o name | grep seldon | grep $(NAMESPACE) | xargs oc delete || true
+	oc get validatingwebhookconfiguration -o name | grep katib | grep $(NAMESPACE) | xargs oc delete || true

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -4,13 +4,13 @@ echo "Installing kfDef from test directory"
 
 set -x
 ## Install the opendatahub-operator
-pushd /peak
-./setup.sh -o /peak/operatorsetup 2>&1
+pushd ~/peak
+./setup.sh -o ~/peak/operatorsetup 2>&1
 echo "Pausing 20 seconds to allow operator to start"
 sleep 20s
 popd
 ## Grabbing and applying the patch in the PR we are testing
-pushd /src/odh-manifests
+pushd ~/src/odh-manifests
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, assuming nightly run"
 else
@@ -21,7 +21,7 @@ else
 fi
 popd
 ## Point kfctl_openshift.yaml to the manifests in the PR
-pushd /kfdef
+pushd ~/kfdef
 if [ -z "$PULL_NUMBER" ]; then
   echo "No pull number, not modifying kfctl_openshift.yaml"
 else
@@ -33,8 +33,8 @@ fi
 
 if [ -z "${OPENSHIFT_USER}" ] || [ -z "${OPENSHIFT_PASS}" ]; then
   echo "Creating HTPASSWD OAuth provider"
-  oc apply -f /peak/operator-tests/odh-manifests/resources/htpasswd.secret.yaml
-  oc apply -f /peak/operator-tests/odh-manifests/resources/oauth.htpasswd.yaml
+  oc apply -f $HOME/peak/operator-tests/odh-manifests/resources/htpasswd.secret.yaml
+  oc apply -f $HOME/peak/operator-tests/odh-manifests/resources/oauth.htpasswd.yaml
   export OPENSHIFT_USER=admin
   export OPENSHIFT_PASS=admin
 fi


### PR DESCRIPTION
This PR adds a Makefile

To test it, you need podman installed and be logged in into the cluster where the test should run.

```
cd tests/
make test
```

You should see the test image built, tests to run and cluster to be cleaned up

~The image now runs as non-root and is based on ubi8/go-toolset to speed up the build time (no need to install golang).~ I could not use the ubi8/go-toolset because the CI rewrites the `FROM`, so I thought I at least put things under `$HOME`, in case we figure out how to change the image in the future...but since the image is always built from master, the tests will fail since they'll look for `/peak` instead of `~/peak`

I added parameterization of Github organization and branch for image build so that you can build the image while developing the tests.