### PR TITLE
Add mixing KFDef example

### DIFF
--- a/kfdef/kfctl_openshift_mix.yaml
+++ b/kfdef/kfctl_openshift_mix.yaml
@@ -1,0 +1,133 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: opendatahub-mix
+  namespace: opendatahub
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-common
+    name: odh-common
+  #Note: AI Library components requires seldon do be deployed first, make sure to place seldon before AIlibrary
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odhseldon/cluster
+    name: odhseldon
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ai-library/cluster
+    name: ai-library-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: ai-library/operator
+    # Note:  In order to utilize ai-library, you also need to have Seldon installed
+    name: ai-library-operator
+  - kustomizeConfig:
+      parameters:
+      # Note: The admin username is admin
+      - name: SUPERSET_ADMIN_PASSWORD
+        value: admin
+      repoRef:
+        name: manifests
+        path: superset
+    name: superset
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: openshift-operators
+      repoRef:
+        name: manifests
+        path: kafka/cluster
+    name: strimzi-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: kafka/kafka
+    name: kafka-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: grafana/cluster
+    name: grafana-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: grafana/grafana
+    name: grafana-instance
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: radanalyticsio/spark/cluster
+    name: radanalyticsio-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: radanalyticsio/spark/operator
+    name: radanalyticsio-spark-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: prometheus/cluster
+    name: prometheus-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: prometheus/operator
+    name: prometheus-operator
+  - kustomizeConfig:
+      parameters:
+        - name: s3_endpoint_url
+          value: "s3.odh.com"
+      repoRef:
+        name: manifests
+        path: jupyterhub/jupyterhub
+    name: jupyterhub
+  - kustomizeConfig:
+      overlays:
+      #- cuda
+      - additional
+      repoRef:
+        name: manifests
+        path: jupyterhub/notebook-images
+    name: notebook-images
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: airflow/operator
+    name: airflow-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: airflow/cluster
+    name: airflow-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odhargo/cluster
+    name: odhargo-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odhargo/odhargo
+    name: odhargo
+  - kustomizeConfig:
+      repoRef:
+        name: kf-manifests
+        path: tf-training/tf-job-crds
+    name: tf-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: kf-manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  repos:
+  - name: kf-manifests
+    uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift  
+  - name: manifests
+    uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
+  version: master


### PR DESCRIPTION
I have simply added the TF Job component to the new KFDef.

I am not sure about what this file's name should be - kfctl_openshift_mix soudns weird, but we have "mixing" in the roadmap, so maybe it makes sense to stick with the term. I am open to ideas:)

To test this:

* deploy ODH operator from catalog
* Use the KFDef from this PR to deploy ODH + TF Job operators
* Build an example from https://github.com/kubeflow/tf-operator/tree/master/examples/v1/dist-mnist
   
   Or you can use my pre-built image here quay.io/vpavlin/tf-dist-mnist-test:1.0 and the example manifest:

   ```
   oc apply -f https://gist.githubusercontent.com/vpavlin/466fa44adf0c6a0e81e4c4cd6abd266a/raw/3c385732d1356eb8bd7636c645d822295eea991e/tf-job-test.yaml
   ```

   You should see bunch of workers started and running and then finish

   ```
   oc describe tfjob dist-mnist-for-e2e-test
   ```
   
   should give you success in the status