### PR TITLE
Parameterize JH tests

### DIFF
--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -6,6 +6,11 @@ MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
 
 source ${MY_DIR}/../util
 
+JH_LOGIN_USER=${OPENSHIFT_USER:-"admin"} #Username used to login to JH
+JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
+OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
+JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
+
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 function test_jupyterhub() {
@@ -26,8 +31,8 @@ function test_start_notebook() {
 
     os::cmd::expect_success "oc project ${ODHPROJECT}"
     route="https://"$(oc get route jupyterhub -o jsonpath='{.spec.host}')
-    os::cmd::expect_success "JH_HEADLESS=true JH_USER_NAME=jh-test JH_LOGIN_USER=admin JH_LOGIN_PASS=admin \
-    JH_NOTEBOOKS=jh-stresstest/test.ipynb JH_NOTEBOOK_IMAGE=s2i-minimal-notebook:3.6 JH_AS_ADMIN=true \
+    os::cmd::expect_success "JH_HEADLESS=true JH_USER_NAME=jh-test JH_LOGIN_USER=${JH_LOGIN_USER} JH_LOGIN_PASS=${JH_LOGIN_PASS} OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER} \
+    JH_NOTEBOOKS=jh-stresstest/test.ipynb JH_NOTEBOOK_IMAGE=s2i-minimal-notebook:3.6 JH_AS_ADMIN=${JH_AS_ADMIN} \
     JH_URL=$route python3 ${MY_DIR}/jupyterhub/jhtest.py"
 }
 

--- a/tests/basictests/jupyterhub/jhtest.py
+++ b/tests/basictests/jupyterhub/jhtest.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from distutils.util import strtobool
 
 from selenium import webdriver
 from selenium.webdriver.support.ui import WebDriverWait
@@ -42,14 +43,15 @@ class JHStress():
         self.url = os.environ.get('JH_URL')
         self.username = os.environ.get('JH_LOGIN_USER')
         self.password = os.environ.get('JH_LOGIN_PASS')
+        self.login_provider = os.environ.get('OPENSHIFT_LOGIN_PROVIDER', 'htpasswd-provider')
         self.notebooks = os.environ.get('JH_NOTEBOOKS', "").split(",")
         self.user_name = os.environ.get('JH_USER_NAME', 'test-user1')
         self.spawner = {
             "image": os.environ.get('JH_NOTEBOOK_IMAGE', "s2i-minimal-notebook:3.6"),
             "size": os.environ.get('JH_NOTEBOOK_SIZE', "None"),
         }
-        self.as_admin = os.environ.get('JH_AS_ADMIN', False)
-        self.headless = os.environ.get('JH_HEADLESS', False)
+        self.as_admin = strtobool(os.environ.get('JH_AS_ADMIN', False))
+        self.headless = strtobool(os.environ.get('JH_HEADLESS', False))
         self.preload_repos = os.environ.get('JH_PRELOAD_REPOS', "https://github.com/vpavlin/jh-stresstest")
 
 
@@ -167,8 +169,8 @@ class JHStress():
         elem = self.driver.find_element_by_link_text("Sign in with OpenShift")
         elem.send_keys(Keys.RETURN)
 
-        if self.check_exists_by_xpath('//a[text()="htpasswd-provider"]'):
-            elem = self.driver.find_element_by_link_text("htpasswd-provider")
+        if self.check_exists_by_xpath('//a[text()="%s"]' % self.login_provider):
+            elem = self.driver.find_element_by_link_text(self.login_provider)
             elem.send_keys(Keys.RETURN)
             self.openshift_login(self.username, self.password)
 

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -31,9 +31,13 @@ else
   fi
 fi
 
-echo "Creating HTPASSWD OAuth provider"
-oc apply -f /peak/operator-tests/odh-manifests/resources/htpasswd.secret.yaml
-oc apply -f /peak/operator-tests/odh-manifests/resources/oauth.htpasswd.yaml
+if [ -z "${OPENSHIFT_USER}" ] || [ -z "${OPENSHIFT_PASS}" ]; then
+  echo "Creating HTPASSWD OAuth provider"
+  oc apply -f /peak/operator-tests/odh-manifests/resources/htpasswd.secret.yaml
+  oc apply -f /peak/operator-tests/odh-manifests/resources/oauth.htpasswd.yaml
+  export OPENSHIFT_USER=admin
+  export OPENSHIFT_PASS=admin
+fi
 
 echo "Creating the following KfDef"
 cat ./kfctl_openshift.yaml

--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -6,10 +6,13 @@ mkdir -p ~/.kube
 cp /var/run/secrets/ci.openshift.io/multi-stage/kubeconfig ~/.kube/config
 chmod 755 ~/.kube/config
 export KUBECONFIG=~/.kube/config
+
+TESTS_REGEX=${TESTS_REGEX:-"basictests"}
+
 # This is needed to avoid `oc status` failing inside openshift-ci
 oc new-project opendatahub
 /peak/install.sh
-/peak/run.sh basictests
+/peak/run.sh ${TESTS_REGEX}
 if [ "$?" -ne 0 ]; then
     echo "The tests failed"
     echo "Here's a dump of the pods:"


### PR DESCRIPTION
This PR adds a bunch of configuration options to JH tests

- OPENSHIFT_USER - a username to be used for login to JH
- OPENSHIFT_PASS - a password to be used for login to JH
- OPENSHIFT_LOGIN_PROVIDER - OpenShift OAuth provider to use (e.g. ldap, kube:admin, htpasswd..)
- JH_AS_ADMIN - assume the user is JH admin - will take a slightly different testing path - e.g. will create a new user in JH (default True)
- TESTS_REGEX - regular expression to match the tests name which should be run (e.g. to limit your local run to the tests you are actually modifying)

WHen a user provides `OPENSHIFT_USER` and `OPENSHIFT_PASS` the `install.sh` will not setup htpasswd provider (to leverage existing user and avoid messing up your dev cluster setup)