### PR TITLE
 Mixing ODH Prometheus and Grafana with Kubeflow

### DIFF
--- a/kfdef/kfctl_openshift_kubeflow_monitoring.yaml
+++ b/kfdef/kfctl_openshift_kubeflow_monitoring.yaml
@@ -1,0 +1,306 @@
+# This is the config to install Kubeflow on an existing k8s cluster.
+# If the cluster already has istio, comment out the istio install part below.
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: kubeflow
+  namespace: kubeflow
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: openshift/openshift-scc
+    name: openshift-scc
+  - kustomizeConfig:
+      repoRef:
+        name: odhmanifests
+        path: odh-common
+    name: odh-common
+  # Istio install. If not needed, comment out istio-crds and istio-install.
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-crds
+    name: istio-crds
+  - kustomizeConfig:
+      overlays:
+      - openshift
+      parameters:
+      - name: namespace
+        value: istio-system
+      repoRef:
+        name: manifests
+        path: istio/istio-install
+    name: istio-install
+  # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
+  - kustomizeConfig:
+      parameters:
+      - name: clusterRbacConfig
+        value: "OFF"
+      repoRef:
+        name: manifests
+        path: istio/istio
+    name: istio
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: metacontroller
+  #   name: metacontroller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      parameters:
+      - name: containerRuntimeExecutor
+        value: k8sapi
+      repoRef:
+        name: manifests
+        path: argo
+    name: argo
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kubeflow-roles
+  #   name: kubeflow-roles
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: common/centraldashboard
+    name: centraldashboard
+  # - kustomizeConfig:
+  #     overlays:
+  #     repoRef:
+  #       name: manifests
+  #       path: admission-webhook/bootstrap
+  #   name: bootstrap
+  # - kustomizeConfig:
+  #     overlays:
+  #     repoRef:
+  #       name: manifests
+  #       path: admission-webhook/webhook
+  #   name: webhook
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: cert-manager
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager-crds
+    name: cert-manager-crds
+  - kustomizeConfig:
+      parameters:
+      - name: namespace
+        value: kube-system
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager-kube-system-resources
+    name: cert-manager-kube-system-resources
+  - kustomizeConfig:
+      overlays:
+      - self-signed
+      parameters:
+      - name: namespace
+        value: cert-manager
+      repoRef:
+        name: manifests
+        path: cert-manager/cert-manager
+    name: cert-manager
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift
+      repoRef:
+        name: manifests
+        path: jupyter/jupyter-web-app
+    name: jupyter-web-app
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - db
+      - openshift
+  #    - crc # If you're running on Code Ready Containers (CRC), you will need this overlay to work around issue https://github.com/code-ready/crc/issues/814
+      repoRef:
+        name: manifests
+        path: metadata
+    name: metadata
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift # We need to use custom controller to overcome fsGroup issue https://github.com/kubeflow/kubeflow/issues/4617
+      repoRef:
+        name: manifests
+        path: jupyter/notebook-controller
+    name: notebook-controller
+  - kustomizeConfig:
+      overlays:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-job-crds
+    name: pytorch-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-operator
+    name: pytorch-operator
+  # - kustomizeConfig:
+  #     parameters:
+  #     - name: namespace
+  #       value: knative-serving
+  #     repoRef:
+  #       name: manifests
+  #       path: knative/knative-serving-crds
+  #   name: knative-crds
+  # - kustomizeConfig:
+  #     parameters:
+  #     - name: namespace
+  #       value: knative-serving
+  #     repoRef:
+  #       name: manifests
+  #       path: knative/knative-serving-install
+  #   name: knative-install
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kfserving/kfserving-crds
+  #   name: kfserving-crds
+  # - kustomizeConfig:
+  #     repoRef:
+  #       name: manifests
+  #       path: kfserving/kfserving-install
+  #   name: kfserving-install
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: tensorboard
+    name: tensorboard
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-crds
+    name: tf-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib/katib-crds
+    name: katib-crds
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift
+      repoRef:
+        name: manifests
+        path: katib/katib-controller
+    name: katib-controller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/api-service
+    name: api-service
+  - kustomizeConfig:
+      overlays:
+      - openshift
+      parameters:
+      - name: minioPvcName
+        value: minio-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/minio
+    name: minio
+  - kustomizeConfig:
+      parameters:
+      - name: mysqlPvcName
+        value: mysql-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/mysql
+    name: mysql
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/persistent-agent
+    name: persistent-agent
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-runner
+    name: pipelines-runner
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-ui
+    name: pipelines-ui
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-viewer
+    name: pipelines-viewer
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/scheduledworkflow
+    name: scheduledworkflow
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipeline-visualization-service
+    name: pipeline-visualization-service
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - openshift #We need custom controller to overcome an istio-injection issue https://github.com/kubeflow/kubeflow/issues/3935
+      parameters:
+      - name: admin
+        value: johnDoe@acme.com
+      repoRef:
+        name: manifests
+        path: profiles
+    name: profiles
+  - kustomizeConfig:
+      overlays:
+      - openshift
+      repoRef:
+        name: manifests
+        path: seldon/seldon-core-operator
+    name: seldon-core-operator
+  - kustomizeConfig:
+      repoRef:
+        name: odhmanifests
+        path: prometheus/cluster
+    name: prometheus-cluster
+  - kustomizeConfig:
+      overlays:
+      - kubeflow
+      repoRef:
+        name: odhmanifests
+        path: prometheus/operator
+    name: prometheus-operator
+  - kustomizeConfig:
+      repoRef:
+        name: odhmanifests
+        path: grafana/cluster
+    name: grafana-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: odhmanifests
+        path: grafana/grafana
+    name: grafana-instance
+  repos:
+  - name: manifests
+    uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift
+  - name: odhmanifests
+    uri: 'https://github.com/opendatahub-io/odh-manifests/tarball/v0.7.0'
+  version: v0.7.0

--- a/prometheus/operator/overlays/kubeflow/kubeflow-servicemonitor.yaml
+++ b/prometheus/operator/overlays/kubeflow/kubeflow-servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    team: opendatahub
+  name: kubeflowmonitor
+spec:
+  endpoints:
+      # for katib and argo
+    - port: metrics
+      # for pytorchjob and tfjob
+    - port: monitoring-port
+  selector: {}

--- a/prometheus/operator/overlays/kubeflow/kustomization.yaml
+++ b/prometheus/operator/overlays/kubeflow/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+
+resources:
+- kubeflow-servicemonitor.yaml


### PR DESCRIPTION
This is part of our efforts to mix and match components between KF and ODH. Here we add prometheus and grafana to KF install with enabled service monitor for tfjobs, pytorchjobs, katib and argo. To test this install KF using ``` kfctl_openshift_kubeflow_monitoring.yaml```
And check the "Target" page in the prometheus portal. You can also run pytorchjobs,tfjobs and katib to see specific metrics. For Argo to work this depends on this PR to merge first: https://github.com/opendatahub-io/manifests/pull/49