### PR TITLE
Switch to notebook images built by Thoth and add tests for each of them

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -3,16 +3,20 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-minimal-notebook"
+    opendatahub.io/notebook-image-name: "Minimal Notebook Image"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with minimal dependency set to start experimenting with Jupyter environment."
   name: s2i-minimal-notebook
 spec:
   lookupPolicy:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-minimal-notebook
+      openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-minimal-notebook:3.6
-    name: "3.6"
+      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+    name: "v0.0.4"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
@@ -3,16 +3,20 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-minimal-notebook"
+    opendatahub.io/notebook-image-name: "SciPy Notebook Image"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image containing basic dependencies for data science and machine learning work."
   name: s2i-scipy-notebook
 spec:
   lookupPolicy:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-scipy-notebook
+      openshift.io/imported-from: quay.io/thoth-station/s2i-scipy-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-scipy-notebook:3.6
-    name: "3.6"
+      name: quay.io/thoth-station/s2i-scipy-notebook:v0.0.1
+    name: "v0.0.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -3,16 +3,20 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-tensorflow-notebook"
+    opendatahub.io/notebook-image-name: "Tensorflow Notebook Image"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image containing dependencies for training Tensorflow models."
   name: s2i-tensorflow-notebook
 spec:
   lookupPolicy:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-tensorflow-notebook
+      openshift.io/imported-from: quay.io/thoth-station/s2i-tensorflow-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-tensorflow-notebook:3.6
-    name: "3.6"
+      name: quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1
+    name: "v0.0.1"
     referencePolicy:
       type: Source

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -41,13 +41,11 @@ RUN pip3 install micropipenv &&\
     cd $HOME/peak &&\
     micropipenv install
 
-COPY basictests $HOME/peak/operator-tests/odh-manifests/basictests
+COPY setup/operatorsetup scripts/install.sh scripts/installandtest.sh $HOME/peak/
 COPY resources $HOME/peak/operator-tests/odh-manifests/resources
 COPY util $HOME/peak/operator-tests/odh-manifests
 COPY setup/kfctl_openshift.yaml $HOME/kfdef/
-COPY setup/operatorsetup $HOME/peak/
-COPY scripts/install.sh $HOME/peak/
-COPY scripts/installandtest.sh $HOME/peak/
+COPY basictests $HOME/peak/operator-tests/odh-manifests/basictests
 
 RUN chmod -R 777 $HOME/kfdef && \
     mkdir -p $HOME/.kube && \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,10 @@
 IMAGE=odh-manifests-test
 GIT_ORG=opendatahub-io
 GIT_BRANCH=master
-NAMESPACE=opendatahub
+ODHPROJECT=opendatahub
+OPENSHIFT_USER=
+OPENSHIFT_PASS=
+OPENSHIFT_LOGIN_PROVIDER=
 SKIP_PODS_OUTPUT=
 # Setting SKIP_INSTALL will let you run the tests against an ODH instance that is already setup
 SKIP_INSTALL=
@@ -15,17 +18,20 @@ build:
 	podman build -t $(IMAGE) --build-arg ORG=$(GIT_ORG) --build-arg BRANCH=$(GIT_BRANCH) .
 
 run:
+	mkdir -p `pwd`/screenshots/
 	oc config view --flatten --minify > /tmp/tests-kubeconfig
-	podman run -e SKIP_PODS_OUTPUT=$(SKIP_PODS_OUTPUT) -e SKIP_INSTALL=$(SKIP_INSTALL) -e TESTS_REGEX=$(TESTS_REGEX) -it -v /tmp/tests-kubeconfig:/tmp/kubeconfig:z $(IMAGE)
+	podman run -e SKIP_PODS_OUTPUT=$(SKIP_PODS_OUTPUT) -e SKIP_INSTALL=$(SKIP_INSTALL) -e TESTS_REGEX=$(TESTS_REGEX) -e ODHPROJECT=$(ODHPROJECT) \
+		-e OPENSHIFT_USER="$(OPENSHIFT_USER)" -e OPENSHIFT_PASS="$(OPENSHIFT_PASS)" -e OPENSHIFT_LOGIN_PROVIDER=$(OPENSHIFT_LOGIN_PROVIDER) \
+		-it -v `pwd`/screenshots/:/tmp/screenshots:z -v /tmp/tests-kubeconfig:/tmp/kubeconfig:z $(IMAGE)
 
 clean:
-	oc delete -n $(NAMESPACE) kfdef opendatahub || true
-	oc delete project $(NAMESPACE) || echo -e "\n\n==> If the project deletion failed, you can try to use this script to force it: https://raw.githubusercontent.com/jefferyb/useful-scripts/master/openshift/force-delete-openshift-project\n\n"
+	oc delete -n $(ODHPROJECT) kfdef opendatahub || true
+	oc delete project $(ODHPROJECT) || echo -e "\n\n==> If the project deletion failed, you can try to use this script to force it: https://raw.githubusercontent.com/jefferyb/useful-scripts/master/openshift/force-delete-openshift-project\n\n"
 	#Clean up openshift-operators namespace
 	oc get csv -n openshift-operators -o name | grep strimzi-cluster-operator | xargs oc delete -n openshift-operators || true
 	oc get csv -n openshift-operators -o name | grep opendatahub-operator | xargs oc delete -n openshift-operators || true
 	oc delete subscription -n openshift-operators -l peak.test.subscription=opendatahub-operator
-	oc get mutatingwebhookconfiguration -o name | grep seldon | grep $(NAMESPACE) | xargs oc delete || true
-	oc get mutatingwebhookconfiguration -o name | grep katib | grep $(NAMESPACE) | xargs oc delete || true
-	oc get validatingwebhookconfiguration -o name | grep seldon | grep $(NAMESPACE) | xargs oc delete || true
-	oc get validatingwebhookconfiguration -o name | grep katib | grep $(NAMESPACE) | xargs oc delete || true
+	oc get mutatingwebhookconfiguration -o name | grep seldon | grep $(ODHPROJECT) | xargs oc delete || true
+	oc get mutatingwebhookconfiguration -o name | grep katib | grep $(ODHPROJECT) | xargs oc delete || true
+	oc get validatingwebhookconfiguration -o name | grep seldon | grep $(ODHPROJECT) | xargs oc delete || true
+	oc get validatingwebhookconfiguration -o name | grep katib | grep $(ODHPROJECT) | xargs oc delete || true

--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -11,6 +11,9 @@ JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
 OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
 JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
 
+JUPYTER_IMAGES=(s2i-minimal-notebook:v0.0.4 s2i-scipy-notebook:v0.0.1 s2i-tensorflow-notebook:v0.0.1 s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3)
+JUPYTER_NOTEBOOK_FILES=(basic.ipynb basic.ipynb tensorflow.ipynb spark.ipynb)
+
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 
 function test_jupyterhub() {
@@ -27,16 +30,28 @@ function test_jupyterhub() {
 }
 
 function test_start_notebook() {
-    header "Testing JupyterHub Notebook Execution"
+    local notebook_name=$1
+    local notebook_file=$2
+    local user=$3
+    local size=${4-Small}
+
+    header "Testing Jupyter Notebook ${notebook_name} Execution (Size: ${size})"
 
     os::cmd::expect_success "oc project ${ODHPROJECT}"
     route="https://"$(oc get route jupyterhub -o jsonpath='{.spec.host}')
-    os::cmd::expect_success "JH_HEADLESS=true JH_USER_NAME=jh-test JH_LOGIN_USER=${JH_LOGIN_USER} JH_LOGIN_PASS=${JH_LOGIN_PASS} OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER} \
-    JH_NOTEBOOKS=jh-stresstest/test.ipynb JH_NOTEBOOK_IMAGE=s2i-minimal-notebook:3.6 JH_AS_ADMIN=${JH_AS_ADMIN} \
-    JH_URL=$route python3 ${MY_DIR}/jupyterhub/jhtest.py"
+    os::cmd::expect_success "JH_HEADLESS=true JH_USER_NAME=${user} JH_LOGIN_USER=${JH_LOGIN_USER} JH_LOGIN_PASS=${JH_LOGIN_PASS} OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER} \
+    JH_NOTEBOOKS=${notebook_file} JH_NOTEBOOK_IMAGE=${notebook_name} JH_AS_ADMIN=${JH_AS_ADMIN} \
+    JH_URL=${route} JH_NOTEBOOK_SIZE=${size} \
+    python3 ${MY_DIR}/jupyterhub/jhtest.py"
+}
+
+function test_notebooks() {
+    for index in ${!JUPYTER_IMAGES[*]}; do
+        test_start_notebook ${JUPYTER_IMAGES[$index]} testing-notebooks/${JUPYTER_NOTEBOOK_FILES[$index]} jh-test${index}
+    done
 }
 
 test_jupyterhub
-test_start_notebook
+test_notebooks
 
 os::test::junit::declare_suite_end

--- a/tests/basictests/jupyterhub/jhtest.py
+++ b/tests/basictests/jupyterhub/jhtest.py
@@ -20,6 +20,7 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 _LOGGER = logging.getLogger()
+_SCREENSHOT_DIR="/tmp/screenshots"
 
 class JHStress():
     def __init__(self):
@@ -52,7 +53,7 @@ class JHStress():
         }
         self.as_admin = strtobool(os.environ.get('JH_AS_ADMIN', False))
         self.headless = strtobool(os.environ.get('JH_HEADLESS', False))
-        self.preload_repos = os.environ.get('JH_PRELOAD_REPOS', "https://github.com/vpavlin/jh-stresstest")
+        self.preload_repos = os.environ.get('JH_PRELOAD_REPOS', "https://github.com/opendatahub-io/testing-notebooks")
 
 
         if not self.url:
@@ -162,7 +163,7 @@ class JHStress():
                 _LOGGER.info("Stopped the server")
         except Exception as e:
             _LOGGER.error(e)
-            self.driver.get_screenshot_as_file("/tmp/exception.png")
+            self.driver.get_screenshot_as_file(os.path.join(_SCREENSHOT_DIR, "exception.png"))
             raise e
 
     def login(self):
@@ -174,7 +175,6 @@ class JHStress():
             elem.send_keys(Keys.RETURN)
             self.openshift_login(self.username, self.password)
 
-        self.driver.get_screenshot_as_file("/tmp/permission.png")
         permissions_xpath = '//input[@value="Allow selected permissions"]'
         if self.check_exists_by_xpath(permissions_xpath):
             elem = spawn_elem = self.driver.find_element(By.XPATH, permissions_xpath)

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -5,7 +5,15 @@ echo "Installing kfDef from test directory"
 set -x
 ## Install the opendatahub-operator
 pushd ~/peak
-./setup.sh -o ~/peak/operatorsetup 2>&1
+retry=5
+while [[ $retry -gt 0 ]]; do
+  ./setup.sh -o ~/peak/operatorsetup 2>&1
+  if [ $? -eq 0 ]; then
+    retry=-1
+  fi
+  retry=$(( retry - 1))
+  sleep 1m
+done
 echo "Pausing 20 seconds to allow operator to start"
 sleep 20s
 popd
@@ -42,9 +50,10 @@ fi
 echo "Creating the following KfDef"
 cat ./kfctl_openshift.yaml
 oc apply -f ./kfctl_openshift.yaml
-set +x
-if [ "$?" -ne 0 ]; then
+kfctl_result=$?
+if [ "$kfctl_result" -ne 0 ]; then
     echo "The installation failed"
-    exit $?
+    exit $kfctl_result
 fi
+set +x
 popd

--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -8,19 +8,21 @@ chmod 644 ~/.kube/config
 export KUBECONFIG=~/.kube/config
 
 TESTS_REGEX=${TESTS_REGEX:-"basictests"}
+ODHPROJECT=${ODHPROJECT:-"opendatahub"}
+export ODHPROJECT
 
 if [ -z "${SKIP_INSTALL}" ]; then
     # This is needed to avoid `oc status` failing inside openshift-ci
-    oc new-project opendatahub
+    oc new-project ${ODHPROJECT}
     $HOME/peak/install.sh
 fi
 $HOME/peak/run.sh ${TESTS_REGEX}
 
-if [ "$?" -ne 0 ]; then
+if  [ "$?" -ne 0 ]; then
     echo "The tests failed"
-    if [ -z "${SKIP_PODS_OUTPUT}"]; then
+    if [ -z "${SKIP_PODS_OUTPUT}" ]; then
         echo "Here's a dump of the pods:"
-        oc get pods -o json -n opendatahub
+        oc get pods -o json -n ${ODHPROJECT}
     fi
     exit 1
 fi

--- a/tests/util
+++ b/tests/util
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Change this if your project is not named opendatahub
-export ODHPROJECT=opendatahub
+export ODHPROJECT=${ODHPROJECT:-"opendatahub"}
 
 millisecond=1
 second=$(( 1000 * millisecond ))


### PR DESCRIPTION
FYI @harshad16

This PR switches our imagestreams to images build by Thoth project. It also improves JH tests to cycle through those images and run notebooks specififc for the image use case (basic, TF, spark..).

NOTE: We need to get stable versions built for scipy and TF notebooks before we can merge this