### PR TITLE
BUGFIX: Update grafana operator v2.0.0 channel to original

### DIFF
--- a/grafana/cluster/base/subscription.yaml
+++ b/grafana/cluster/base/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grafana-operator
   namespace: opendatahub
 spec:
-  channel: alpha
+  channel: original
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators


### PR DESCRIPTION
With the release of grafana-operator.v3.5.0, v2.0.0 now lives in the `original` channel and v3.5.0 is in the `alpha` channel. 