### PR TITLE
Update kf-manifest ref to v1.0-branch-openshift

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -117,7 +117,7 @@ spec:
     name: odhargo
   repos:
   - name: kf-manifests
-    uri: https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift  
+    uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift
   - name: manifests
     uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
   version: v0.7-branch-openshift


### PR DESCRIPTION
Updating the `kfctl_openshift.yaml` repo reference for kf-manifests to point to `v1.0-branch-openshift`

Steps to test:
* Deploy odh with this modified manifest 
