### PR TITLE
Add Elyra to list of notebooks available for ODH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 kfdef/.cache/
 kfdef/kustomize/
 tests/kubeconfig
+.idea

--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -17,6 +17,10 @@ data:
             memory: 2Gi
             cpu: 1
 
+      - name: Elyra Notebook
+        images:
+        - 's2i-elyra-notebook:1.0.0'
+
       - name: Spark Notebook
         images:
         - 's2i-spark-minimal-notebook:3.6'

--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -17,10 +17,6 @@ data:
             memory: 2Gi
             cpu: 1
 
-      - name: Elyra Notebook
-        images:
-        - 's2i-elyra-notebook:1.0.0'
-
       - name: Spark Notebook
         images:
         - 's2i-spark-minimal-notebook:3.6'

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -1,0 +1,18 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  name: s2i-elyra-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      openshift.io/imported-from: quay.io/akchinstc/s2i-elyra-notebook
+    from:
+      kind: DockerImage
+      name: quay.io/akchinstc/s2i-elyra-notebook:1.0.0
+    name: "1.0.0"
+    referencePolicy:
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -3,16 +3,20 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
-  name: s2i-elyra-notebook
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-lab-elyra"
+    opendatahub.io/notebook-image-name: "Elyra Notebook Image"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with Elyra-AI installed"
+  name: s2i-lab-elyra
 spec:
   lookupPolicy:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/akchinstc/s2i-elyra-notebook
+      openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/akchinstc/s2i-elyra-notebook:1.0.0
-    name: "1.0.0"
+      name: quay.io/thoth-station/s2i-lab-elyra:0.0.1
+    name: "0.0.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:0.0.1
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.1
     name: "0.0.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.1
-    name: "0.0.1"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.2
+    name: "0.0.2"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - scipy-notebook-imagestream.yaml
 - tensorflow-notebook-imagestream.yaml
 - spark-scipy-notebook-imagestream.yaml
+- elyra-notebook-imagestream.yaml
 
 commonLabels:
   opendatahub.io/component: "true"

--- a/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
@@ -2,23 +2,22 @@ apiVersion: build.openshift.io/v1
 kind: BuildConfig
 metadata:
   labels:
-    build: s2i-elyra-notebook
-  name: s2i-elyra-notebook
+    build: s2i-lab-elyra
+  name: s2i-lab-elyra
 spec:
   output:
     to:
       kind: ImageStreamTag
-      name: s2i-elyra-notebook:1.0.0
+      name: quay.io/thoth-station/s2i-lab-elyra:0.0.1
   source:
-    contextDir: elyra-notebook
     git:
-      uri: https://github.com/akchinSTC/jupyter-notebooks
+      uri: https://github.com/opendatahub-io/s2i-lab-elyra
     type: Git
   strategy:
     sourceStrategy:
       from:
         kind: ImageStreamTag
-        name: s2i-minimal-notebook:3.6
+        name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
     type: Source
   triggers:
   - type: ConfigChange

--- a/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
@@ -1,0 +1,24 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    build: s2i-elyra-notebook
+  name: s2i-elyra-notebook
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: s2i-elyra-notebook:1.0.0
+  source:
+    contextDir: elyra-notebook
+    git:
+      uri: https://github.com/akchinSTC/jupyter-notebooks
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: s2i-minimal-notebook:3.6
+    type: Source
+  triggers:
+  - type: ConfigChange

--- a/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
@@ -8,7 +8,7 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: quay.io/thoth-station/s2i-lab-elyra:0.0.1
+      name: s2i-lab-elyra:v0.0.1
   source:
     git:
       uri: https://github.com/opendatahub-io/s2i-lab-elyra
@@ -17,7 +17,7 @@ spec:
     sourceStrategy:
       from:
         kind: ImageStreamTag
-        name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+        name: s2i-minimal-notebook:v0.0.4
     type: Source
   triggers:
   - type: ConfigChange

--- a/jupyterhub/notebook-images/overlays/build/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/build/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - spark-minimal-notebook-buildconfig.yaml
 - spark-scipy-notebook-buildconfig.yaml
 - nbviewer-buildconfig.yaml
+- elyra-notebook-buildconfig.yaml
 
 commonLabels:
   opendatahub.io/component: "true"


### PR DESCRIPTION
- Adds Elyra build configs and Imagestream

Will need to rebase images to official ones in dockerhub when they get published