### PR TITLE
Add Kafka integration tests

### DIFF
--- a/tests/Pipfile.lock
+++ b/tests/Pipfile.lock
@@ -26,10 +26,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:3de946ffbed6e6746608990594d08faac602528ac7015ac28d33cee6a45b7398",
-                "sha256:9a107b99a5393caf59c7aa3c1249c16e6879447533d0887f4336dde834c7be86"
+                "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a",
+                "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"
             ],
-            "version": "==1.25.6"
+            "version": "==1.25.10"
         }
     },
     "develop": {}

--- a/tests/basictests/kafka.sh
+++ b/tests/basictests/kafka.sh
@@ -3,6 +3,7 @@
 source $TEST_DIR/common
 
 MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+KAFKA_TEST_JOB="${MY_DIR}/../resources/kafka-test.job.yaml"
 
 source ${MY_DIR}/../util
 
@@ -24,6 +25,13 @@ function test_kafka() {
     os::cmd::expect_success_and_text "echo ${#runningbuspods[@]}" "7"
 }
 
+function test_kafka_consumer_producer() {
+    oc apply -n "${ODHPROJECT}" -f ${KAFKA_TEST_JOB}
+    os::cmd::try_until_text "oc logs -l job-name=kafka-test" "Producer produced a message"
+    oc delete -n "${ODHPROJECT}" -f ${KAFKA_TEST_JOB}
+}
+
 test_kafka
+test_kafka_consumer_producer
 
 os::test::junit::declare_suite_end

--- a/tests/resources/kafka-test.job.yaml
+++ b/tests/resources/kafka-test.job.yaml
@@ -1,0 +1,21 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kafka-test
+  labels:
+    app: kafka-test
+spec:
+  template:
+    spec:
+      containers:
+      - name: kafka-test
+        image: quay.io/opendatahub-ci/kafka-test:latest
+        env:
+          - name: APP_FILE
+            value: app.sh
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      restartPolicy: Never
+  backoffLimit: 1

--- a/tests/resources/kafka/Makefile
+++ b/tests/resources/kafka/Makefile
@@ -1,0 +1,13 @@
+IMAGE=quay.io/opendatahub-ci/kafka-test:latest
+USE_BUILDER=
+WITH_BUILDER=docker
+ifneq ($(WITH_BUILDER), docker)
+USE_BUILDER=--with-builder $(WITH_BUILDER)
+endif
+
+all: build push
+
+build:
+	s2i $(USE_BUILDER) build ./image/ ubi7/python-36 $(IMAGE)
+push:
+	podman push $(IMAGE)

--- a/tests/resources/kafka/image/app.sh
+++ b/tests/resources/kafka/image/app.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 ./producer/producer.py &
+python3 ./consumer/consumer.py

--- a/tests/resources/kafka/image/consumer/consumer.py
+++ b/tests/resources/kafka/image/consumer/consumer.py
@@ -1,0 +1,20 @@
+from kafka import KafkaConsumer
+import os
+import json
+
+consumer = KafkaConsumer("test",group_id="test-group",auto_offset_reset='earliest',bootstrap_servers='odh-message-bus-kafka-bootstrap.%s.svc.cluster.local:9092' % os.environ['NAMESPACE'])
+
+try:
+    for record in consumer:
+        msg = record.value.decode('utf-8')
+        print(msg)
+        if msg == "\"Producer produced a message\"":
+            break
+except KeyboardInterrupt:
+    pass
+finally:
+    # Don't forget to clean up after yourself!
+    print("Closing KafkaConsumer...")
+    consumer.close()
+
+print("done")

--- a/tests/resources/kafka/image/producer/producer.py
+++ b/tests/resources/kafka/image/producer/producer.py
@@ -1,0 +1,12 @@
+from kafka import KafkaProducer
+import time
+import random
+import os
+import json
+
+for i in range(10):
+    time_slept = random.uniform(0,3)
+    time.sleep(time_slept)
+    producer=KafkaProducer(bootstrap_servers='odh-message-bus-kafka-bootstrap.%s.svc.cluster.local:9092' % os.environ['NAMESPACE'])
+    producer.send("test",json.dumps(f"Producer produced a message").encode('utf-8'))
+    producer.flush()

--- a/tests/resources/kafka/image/requirements.txt
+++ b/tests/resources/kafka/image/requirements.txt
@@ -1,0 +1,1 @@
+kafka-python


### PR DESCRIPTION
This PR adds an image which serves as a producer/consumer and a simple test job which runs the image and checks the logs to see if consumer consumed

~The image is currently pushed under my user in quay - where should it go - opendatahub, opendatahub-ci?~

EDIT: image is being pushed to https://quay.io/repository/opendatahub-ci/kafka-test?tab=tags

Fixes: #172 