### PR TITLE
Add odh-dashboard manifests.

### DIFF
--- a/kfdef/kfctl_openshift.yaml
+++ b/kfdef/kfctl_openshift.yaml
@@ -115,6 +115,11 @@ spec:
         name: manifests
         path: odhargo/odhargo
     name: odhargo
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+    name: odh-dashboard
   repos:
   - name: kf-manifests
     uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift

--- a/kfdef/kfctl_openshift_distributed_training.yaml
+++ b/kfdef/kfctl_openshift_distributed_training.yaml
@@ -135,6 +135,11 @@ spec:
         name: kf-manifests
         path: pytorch-job/pytorch-operator
     name: pytorch-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+    name: odh-dashboard
   repos:
   - name: kf-manifests
     uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift  

--- a/odh-dashboard/README.md
+++ b/odh-dashboard/README.md
@@ -1,0 +1,24 @@
+# Dashboard
+
+The Open Data Hub Dashboard component installs a UI which 
+
+- Shows what's installed
+- Show's what's available for installation
+- Links to component UIs
+- Links to component documentation
+
+For more information, visit the project [GitHub repo](https://github.com/opendatahub-io/odh-dashboard).
+
+### Folders
+There is one main folder in the Dashboard component
+1. base: contains all the necessary yaml files to install the dashboard
+
+##### Installation
+```
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+    name: odh-dashboard
+```
+

--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: odh-dashboard
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      deployment: odh-dashboard
+  template:
+    metadata:
+      labels:
+        deployment: odh-dashboard
+    spec:
+      serviceAccount: odh-dashboard
+      containers:
+      - name: odh-dashboard
+        image: quay.io/opendatahub/odh-dashboard:v0.9
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: 250m
+            memory: 300Mi
+          limits:
+            cpu: 500m
+            memory: 1000Mi
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 15
+          periodSeconds: 30
+          successThreshold: 1
+          failureThreshold: 3

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: odh-dashboard
+  app.kubernetes.io/part-of: odh-dashboard
+resources:
+- role.yaml
+- service-account.yaml
+- role-binding.yaml
+- deployment.yaml
+- routes.yaml
+- service.yaml

--- a/odh-dashboard/base/role-binding.yaml
+++ b/odh-dashboard/base/role-binding.yaml
@@ -1,0 +1,11 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: odh-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: odh-dashboard

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -1,0 +1,21 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+rules:
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - kfdef.apps.kubeflow.org
+    resources:
+      - kfdefs
+    verbs:
+      - get
+      - list
+      - watch

--- a/odh-dashboard/base/routes.yaml
+++ b/odh-dashboard/base/routes.yaml
@@ -1,0 +1,16 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  annotations:
+    kubernetes.io/tls-acme: 'true'
+  name: odh-dashboard
+spec:
+  port:
+    targetPort: 8080
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: odh-dashboard
+    weight: 100

--- a/odh-dashboard/base/service-account.yaml
+++ b/odh-dashboard/base/service-account.yaml
@@ -1,0 +1,4 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: odh-dashboard

--- a/odh-dashboard/base/service.yaml
+++ b/odh-dashboard/base/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: odh-dashboard
+spec:
+  selector:
+    deployment: odh-dashboard
+  type: LoadBalancer
+  ports:
+  - protocol: TCP
+    targetPort: 8080
+    port: 8080

--- a/tests/basictests/dashboard.sh
+++ b/tests/basictests/dashboard.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function check_resources() {
+    header "Testing dashboard installation"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    os::cmd::try_until_text "oc get odh-dashboard odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get role odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get rolebinding odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get route odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get service odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get deployment odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -l deployment=odh-dashboard --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
+    runningpods=($(oc get pods -l deployment=odh-dashboard --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "2"
+}
+
+function check_ui() {
+    header "Testing dashboard UI loads"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    local route="https://"$(oc get route odh-dashboard -o jsonpath='{.spec.host}')
+    os::log::info "$route"
+    os::cmd::try_until_text "curl -k -s -o /dev/null -w \"%{http_code}\" $route/api/components" "200" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -k $route/api/components | jq '.[].key'" "jupyterhub" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -k $route" "<title>Open Data Hub Dashboard</title>" $odhdefaulttimeout $odhdefaultinterval
+}
+
+check_resources
+check_ui
+
+os::test::junit::declare_suite_end

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -117,6 +117,11 @@ spec:
         name: manifests
         path: kafka/kafka
     name: kafka-cluster
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+    name: odh-dashboard
   repos:
   - name: kf-manifests
     uri: https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift  


### PR DESCRIPTION
Adds templates and tests to add the [ODH Dashboard](https://github.com/opendatahub-io/odh-dashboard) as part of the Open Data Hub installation.