### PR TITLE
Bump elyra image up to v0.0.5

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.2
-    name: "0.0.2"
+      name: quay.io/thoth-station/s2i-lab-elyra:6
+    name: "6"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.4
-    name: "v0.0.4"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.5
+    name: "v0.0.5"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:6
-    name: "6"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.4
+    name: "v0.0.4"
     referencePolicy:
       type: Source


### PR DESCRIPTION
Updated:
Bumped Elyra to v0.0.5.  Missing oc4 binary has been fixed.

Original:
Bump version of elyra up to v0.0.4 to resolve startup issues stemming from missing oc4 binary. 