### PR TITLE
Move superset database init to a kubernetes job

### DIFF
--- a/superset/README.md
+++ b/superset/README.md
@@ -24,3 +24,10 @@ To install Superset add the following to the `kfctl` yaml file.
 ```
 
 By default the user and password to the Superset portal is admin/admin. You can change the password by changing the value of the `SUPERSET_ADMIN_PASSWORD`. To launch the portal, go to the routes in the namespace you installed Open Data Hub and click on the route with `superset` name.
+
+### Superset Database Initialization
+
+Prior to running, Superset's database must be initialized. This is handled via the `superset-db-init` Kubernetes
+job. Upon deployment, this job will be created and run once. There will likely be a brief period of time that
+the Superset container will fail before the initialization completes. Once this is done, the Superset pod should
+start running without intervention.

--- a/superset/base/db-init-job.yaml
+++ b/superset/base/db-init-job.yaml
@@ -1,27 +1,17 @@
-apiVersion: apps.openshift.io/v1
-kind: DeploymentConfig
+apiVersion: batch/v1
+kind: Job
 metadata:
-  name: superset
+  name: superset-db-init
   namespace: opendatahub
-  labels:
-    app: superset
-    opendatahub.io/component: "true"
-    component.opendatahub.io/name: superset
 spec:
-  replicas: 1
-  selector:
-    deploymentconfig: superset
+  parallelism: 1
+  completions: 1
   template:
     metadata:
-      labels:
-        app: superset
-        deploymentconfig: superset
+      name: superset-db-init
     spec:
       containers:
-        - name: superset
-          command:
-            - /bin/sh
-            - entrypoint.sh
+        - name: superset-init
           envFrom:
             - configMapRef:
                 name: superset
@@ -29,9 +19,10 @@ spec:
                 name: superset-secret
           image: quay.io/aiops/superset:v0.30
           imagePullPolicy: Always
-          ports:
-            - containerPort: 8088
-              protocol: TCP
+          command:
+            - /bin/sh
+            - /usr/local/bin/superset-init
+            - --username $(SUPERSET_ADMIN_USER) --firstname $(SUPERSET_ADMIN_FNAME) --lastname $(SUPERSET_ADMIN_LNAME) --email $(SUPERSET_ADMIN_EMAIL) --password $(SUPERSET_ADMIN_PASSWORD)
           volumeMounts:
             - mountPath: /var/lib/superset
               name: superset-data
@@ -48,5 +39,4 @@ spec:
                 path: superset_config.py
             name: superset
           name: superset-config
-  triggers:
-    - type: ConfigChange
+      restartPolicy: OnFailure

--- a/superset/base/kustomization.yaml
+++ b/superset/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - pvc.yaml
 - configmap.yaml
 - deploymentconfig.yaml
+- db-init-job.yaml
 - service.yaml
 - route.yaml
 namespace: opendatahub


### PR DESCRIPTION
Previously the superset database init ran as an init container in the
superset pod. This resulted in the database getting initialized at every
pod startup and reverting any permissions changes.

This change moves the init call into a kubernetes job that will run only
once.