### PR TITLE
Update Grafana Operator Version

### DIFF
--- a/grafana/cluster/base/subscription.yaml
+++ b/grafana/cluster/base/subscription.yaml
@@ -4,9 +4,9 @@ metadata:
   name: grafana-operator
   namespace: opendatahub
 spec:
-  channel: original
+  channel: alpha
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v2.0.0
+  startingCSV: grafana-operator.v3.6.0

--- a/grafana/grafana/base/grafana.yaml
+++ b/grafana/grafana/base/grafana.yaml
@@ -16,7 +16,7 @@ spec:
       disable_login_form: False
       disable_signout_menu: True
     auth.basic:
-      enabled: False
+      enabled: True
     auth.anonymous:
       enabled: True
   dashboardLabelSelector:


### PR DESCRIPTION
This will update the grafana operator version to the latest available community operator.

https://github.com/operator-framework/community-operators/blob/master/community-operators/grafana-operator/3.6.0/grafana-operator.v3.6.0.clusterserviceversion.yaml