### PR TITLE
feat(data-catalog): Adding Hue

### DIFF
--- a/hue/README.md
+++ b/hue/README.md
@@ -1,0 +1,53 @@
+# Cloudera Hue
+
+Deploys the Cloudera Hue server allowing data exploration on Hive and S3 buckets.
+
+Cloudera Hue is expected to be deployed along any HiveServer2 type of service. In Open Data Hub a [Spark SQL Thrift Server](../thriftserver) is used. Without Thrift Server deployment, Hue won't be able to fulfil any SQL queries. However it can still serve as an S3 browser.
+
+### Folders
+
+There is one main folder in the Hue component `hue` which contains the kustomize manifests.
+
+### Installation
+
+To install Hue add the following to the `kfctl` yaml file.
+
+```yaml
+- kustomizeConfig:
+    repoRef:
+      name: manifests
+      path: hue/hue
+  name: hue
+```
+
+### Overlays
+
+Hue component provides a single overlay.
+
+#### storage-class
+
+Customizes Hue's database to use a specific `StorageClass` for PVC, see `storage_class` parameter.
+
+### Parameters
+
+There are 4 parameters exposed vie KFDef.
+
+#### storage_class
+
+Name of the storage class to be used for PVC created by Hue's database. This requires `storage-class` **overlay** to be enabled as well to work.
+
+#### hue_secret_key
+
+Set session store secret key for Hue web server.
+
+#### s3_endpoint_url
+
+HTTP endpoint exposed by your S3 object storage solution which will be made available to Hue as the default S3 filesystem location.
+
+#### s3_is_secure
+
+Specifies if HTTPS should be used as a transport protocol. Set to `true` for HTTPS and to `false` to use HTTP. Parameter is set to `true` by default.
+
+#### s3_credentials_secret
+
+Along with `s3_endpoint_url`, this parameter configures the Hue's access to S3 object storage. Setting this parameter to any name of local Openshift/Kubernetes Secret resource name would allow Hue to consume S3 credentials from it. The secret of choice must contain `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys. Keep in mind, in order for this value to be respected by Spark cluster properly, it must use the same credentials. If not set, credentials from [`hue-sample-s3-secret`](hue/base/hue-sample-s3-secret.yaml) will be used instead.

--- a/hue/hue/base/hive-site-xml-secret.yaml
+++ b/hue/hue/base/hive-site-xml-secret.yaml
@@ -1,0 +1,68 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hue-hive-site-xml
+type: Opaque
+stringData:
+  hive-site.xml: |
+    <?xml version="1.0"?>
+    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+    <configuration>
+      <property>
+        <name>hive.server2.transport.mode</name>
+        <value>binary</value>
+        <description>Server transport mode. binary or http.</description>
+      </property>
+
+      <property>
+        <name>hive.server2.thrift.http.port</name>
+        <value>10000</value>
+        <description>Port number when in HTTP mode.</description>
+      </property>
+
+      <property>
+        <name>fs.s3a.aws.credentials.provider</name>
+        <value>com.amazonaws.auth.EnvironmentVariableCredentialsProvider</value>
+        <description>
+          Comma-separated class names of credential provider classes which implement
+          com.amazonaws.auth.AWSCredentialsProvider.
+
+          These are loaded and queried in sequence for a valid set of credentials.
+          Each listed class must implement one of the following means of
+          construction, which are attempted in order:
+          1. a public constructor accepting java.net.URI and
+              org.apache.hadoop.conf.Configuration,
+          2. a public static method named getInstance that accepts no
+            arguments and returns an instance of
+            com.amazonaws.auth.AWSCredentialsProvider, or
+          3. a public default constructor.
+
+          Specifying org.apache.hadoop.fs.s3a.AnonymousAWSCredentialsProvider allows
+          anonymous access to a publicly accessible S3 bucket without any credentials.
+          Please note that allowing anonymous access to an S3 bucket compromises
+          security and therefore is unsuitable for most use cases. It can be useful
+          for accessing public data sets without requiring AWS credentials.
+
+          If unspecified, then the default list of credential provider classes,
+          queried in sequence, is:
+          1. org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider:
+            Uses the values of fs.s3a.access.key and fs.s3a.secret.key.
+          2. com.amazonaws.auth.EnvironmentVariableCredentialsProvider: supports
+              configuration of AWS access key ID and secret access key in
+              environment variables named AWS_ACCESS_KEY_ID and
+              AWS_SECRET_ACCESS_KEY, as documented in the AWS SDK.
+          3. com.amazonaws.auth.InstanceProfileCredentialsProvider: supports use
+              of instance profile credentials if running in an EC2 VM.
+        </description>
+      </property>
+
+      <property>
+        <name>fs.s3a.endpoint</name>
+        <value>$(s3_endpoint_url)</value>
+        <description>AWS S3 endpoint to connect to. An up-to-date list is
+          provided in the AWS Documentation: regions and endpoints. Without this
+          property, the standard region (s3.amazonaws.com) is assumed.
+        </description>
+      </property>
+    </configuration>

--- a/hue/hue/base/hue-ini-secret.yaml
+++ b/hue/hue/base/hue-ini-secret.yaml
@@ -1,0 +1,210 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hue-ini
+type: Opaque
+stringData:
+  hue.ini: |
+    # Full configuration:
+    # https://github.com/cloudera/hue/blob/master/desktop/conf.dist/hue.ini
+
+    [desktop]
+      # Hide unused apps
+      app_blacklist=impala,security,jobbrowser,jobsub,pig,hbase,sqoop,zookeeper,spark,oozie,search
+      secret_key=$(hue_secret_key)
+      http_host=0.0.0.0
+      http_port=8000
+      time_zone=America/Los_Angeles
+      django_debug_mode=false
+      dev=false
+      database_logging=false
+      send_dbug_messages=false
+      http_500_debug_mode=false
+      enable_prometheus=true
+
+      [[django_admins]]
+
+      [[custom]]
+
+      [[auth]]
+
+      [[ldap]]
+        [[[users]]]
+
+        [[[groups]]]
+
+        [[[ldap_servers]]]
+
+      [[vcs]]
+
+      [[database]]
+        engine=mysql
+        host=hue-mysql.$(namespace).svc
+        port=3306
+        user=$(database_user)
+        password=$(database_password)
+        name=$(database_name)
+
+      [[session]]
+
+      [[smtp]]
+        host=localhost
+        port=25
+        user=
+        password=
+        tls=no
+
+      [[knox]]
+
+      [[kerberos]]
+
+      [[oauth]]
+
+      [[oidc]]
+
+      [[metrics]]
+
+      [[tracing]]
+
+      [[task_server]]
+
+      [[gc_accounts]]
+        [[[default]]]
+
+    [notebook]
+      [[interpreters]]
+        [[[hive]]]
+          name=Hive
+          interface=hiveserver2
+
+        [[[impala]]]
+          name=Impala
+          interface=hiveserver2
+
+        [[[sparksql]]]
+          name=SparkSql
+          interface=hiveserver2
+
+        [[[text]]]
+          name=Text
+          interface=text
+
+        [[[markdown]]]
+          name=Markdown
+          interface=text
+
+    [dashboard]
+      is_enabled=true
+      has_sql_enabled=true
+      has_report_enabled=true
+      use_gridster=true
+      has_widget_filter=false
+      has_tree_widget=false
+
+      [[engines]]
+        [[[solr]]]
+        analytics=true
+        nesting=true
+
+        [[[sql]]]
+        analytics=true
+        nesting=false
+
+    [hadoop]
+      [[hdfs_clusters]]
+        [[[default]]]
+
+      [[yarn_clusters]]
+        [[[default]]]
+
+    [beeswax]
+      hive_server_host=thriftserver.$(namespace).svc
+      hive_server_port=10000
+      hive_conf_dir=/etc/hive/conf
+      thrift_version=7
+
+      [[ssl]]
+
+    [metastore]
+      enable_new_create_table=true
+      force_hs2_metadata=false
+
+    [impala]
+      [[ssl]]
+
+    [spark]
+
+    [oozie]
+
+    [filebrowser]
+
+    [pig]
+
+    [sqoop]
+
+    [proxy]
+
+    [hbase]
+
+    [search]
+
+    [libsolr]
+
+    [indexer]
+
+    [jobsub]
+
+    [jobbrowser]
+
+    [security]
+
+    [zookeeper]
+      [[clusters]]
+        [[[default]]]
+
+    [useradmin]
+      [[password_policy]]
+
+    [liboozie]
+      oozie_url=
+
+    [aws]
+      [[aws_accounts]]
+        [[[default]]]
+          host=$(s3_endpoint_url)
+          is_secure=$(s3_is_secure)
+          calling_format=boto.s3.connection.OrdinaryCallingFormat
+          access_key_id_script=/opt/hue/aws_access_key_id.sh
+          secret_access_key_script=/opt/hue/aws_secret_access_key.sh
+
+    [azure]
+      [[azure_accounts]]
+        [[[default]]]
+
+      [[adls_clusters]]
+        [[[default]]]
+
+      [[abfs_clusters]]
+        [[[default]]]
+
+    [libsentry]
+
+    [libzookeeper]
+
+    [librdbms]
+      [[databases]]
+
+    [libsaml]
+
+    [liboauth]
+
+    [kafka]
+      [[kafka]]
+
+    [metadata]
+      [[manager]]
+      [[optimizer]]
+      [[catalog]]
+      [[navigator]]
+      [[prometheus]]

--- a/hue/hue/base/hue-mysql-pvc.yaml
+++ b/hue/hue/base/hue-mysql-pvc.yaml
@@ -1,0 +1,11 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: hue-mysql
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "1Gi"

--- a/hue/hue/base/hue-mysql-secret.yaml
+++ b/hue/hue/base/hue-mysql-secret.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hue-mysql
+stringData:
+  database-user: datacatalog
+  database-password: datacatalog
+  database-name: datacatalog
+  database-root-password: root

--- a/hue/hue/base/hue-mysql-service.yaml
+++ b/hue/hue/base/hue-mysql-service.yaml
@@ -1,0 +1,24 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: hue-mysql
+  annotations:
+    template.openshift.io/expose-uri: |
+      'mysql://{.spec.clusterIP}:{.spec.ports[?(.name=="mysql")].port}'
+spec:
+  ports:
+    - name: mysql
+      protocol: TCP
+      port: 3306
+      targetPort: 3306
+    - name: exporter
+      protocol: TCP
+      port: 9104
+      targetPort: 9104
+  selector:
+    deployment: hue-mysql
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}

--- a/hue/hue/base/hue-mysql.yaml
+++ b/hue/hue/base/hue-mysql.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hue-mysql
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+spec:
+  replicas: 1
+  selector:
+    deployment: hue-mysql
+  template:
+    metadata:
+      labels:
+        deployment: hue-mysql
+    spec:
+      containers:
+        - name: mysqld-exporter
+          image: mysqld-exporter
+          ports:
+            - containerPort: 9104
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: "hue-mysqld-exporter"
+                  key: DATA_SOURCE_NAME
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9104
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9104
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 200m
+              memory: 300Mi
+        - name: mysql
+          image: mysql
+          ports:
+            - containerPort: 3306
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - "-i"
+                - "-c"
+                - >-
+                  MYSQL_PWD=$MYSQL_PASSWORD mysql -h 127.0.0.1 -u $MYSQL_USER -D
+                  $MYSQL_DATABASE -e 'SELECT 1'
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            tcpSocket:
+              port: 3306
+            timeoutSeconds: 1
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: "hue-mysql"
+                  key: database-user
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "hue-mysql"
+                  key: database-password
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: "hue-mysql"
+                  key: database-name
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "hue-mysql"
+                  key: database-root-password
+          resources:
+            requests:
+              cpu: 300m
+              memory: 500Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: "mysql"
+              mountPath: "/var/lib/mysql/data"
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          capabilities: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+      volumes:
+        - name: mysql
+          persistentVolumeClaim:
+            claimName: hue-mysql
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst

--- a/hue/hue/base/hue-mysqld-exporter-secret.yaml
+++ b/hue/hue/base/hue-mysqld-exporter-secret.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hue-mysqld-exporter
+stringData:
+  DATA_SOURCE_NAME: "root@(localhost:3306)/$(database_name)"

--- a/hue/hue/base/hue-route.yaml
+++ b/hue/hue/base/hue-route.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hue
+spec:
+  port:
+    targetPort: 8000-tcp
+  tls:
+    termination: edge
+  to:
+    kind: Service
+    name: hue
+    weight: 100
+  wildcardPolicy: None

--- a/hue/hue/base/hue-sample-s3-secret.yaml
+++ b/hue/hue/base/hue-sample-s3-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: hue-sample-s3
+stringData:
+  AWS_ACCESS_KEY_ID: SECRET_KEY_ID
+  AWS_SECRET_ACCESS_KEY: SECRET_ACCESS_KEY

--- a/hue/hue/base/hue-service.yaml
+++ b/hue/hue/base/hue-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hue
+spec:
+  selector:
+    deployment: hue
+  ports:
+    - name: 8000-tcp
+      port: 8000
+      protocol: TCP
+      targetPort: 8000

--- a/hue/hue/base/hue.yaml
+++ b/hue/hue/base/hue.yaml
@@ -1,0 +1,72 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hue
+spec:
+  replicas: 1
+  selector:
+    deployment: hue
+  template:
+    metadata:
+      labels:
+        deployment: hue
+    spec:
+      initContainers:
+        - name: db-init
+          image: hue
+          args: ["migrate"]
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: hue-ini
+              mountPath: /opt/hue/desktop/conf/
+      containers:
+        - name: hue
+          image: hue
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 300m
+              memory: 500Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          env:
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_SECRET_ACCESS_KEY
+          volumeMounts:
+            - name: hue-ini
+              mountPath: /opt/hue/desktop/conf/
+            - name: hive-site-xml
+              mountPath: /etc/hive/conf/
+          ports:
+            - containerPort: 8000
+          livenessProbe:
+            httpGet:
+              path: /desktop/debug/is_alive
+              port: 8000
+            initialDelaySeconds: 3
+            periodSeconds: 30
+            failureThreshold: 5
+      restartPolicy: Always
+      volumes:
+        - name: hue-ini
+          secret:
+            secretName: hue-ini
+            items:
+              - key: hue.ini
+                path: hue.ini
+        - name: hive-site-xml
+          secret:
+            secretName: hue-hive-site-xml
+            items:
+              - key: hive-site.xml
+                path: hive-site.xml

--- a/hue/hue/base/kustomization.yaml
+++ b/hue/hue/base/kustomization.yaml
@@ -1,0 +1,107 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hive-site-xml-secret.yaml
+  - hue-ini-secret.yaml
+  - hue-mysql-pvc.yaml
+  - hue-mysql-secret.yaml
+  - hue-mysql-service.yaml
+  - hue-mysql.yaml
+  - hue-mysqld-exporter-secret.yaml
+  - hue-route.yaml
+  - hue-sample-s3-secret.yaml
+  - hue-service.yaml
+  - hue.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: hue
+  component.opendatahub.io/part-of: datacatalog
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: hue-config
+    envs:
+      - params.env
+
+vars:
+  - name: namespace
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: hue
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: storage_class
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: hue-config
+    fieldref:
+      fieldpath: data.storage_class
+  - name: hue_secret_key
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: hue-config
+    fieldref:
+      fieldpath: data.hue_secret_key
+  - name: s3_endpoint_url
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: hue-config
+    fieldref:
+      fieldpath: data.s3_endpoint_url
+  - name: s3_is_secure
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: hue-config
+    fieldref:
+      fieldpath: data.s3_is_secure
+  - name: s3_credentials_secret
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: hue-config
+    fieldref:
+      fieldpath: data.s3_credentials_secret
+  - name: database_user
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: hue-mysql
+    fieldref:
+      fieldpath: stringData.database-user
+  - name: database_password
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: hue-mysql
+    fieldref:
+      fieldpath: stringData.database-password
+  - name: database_name
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: hue-mysql
+    fieldref:
+      fieldpath: stringData.database-name
+
+configurations:
+  - params.yaml
+
+images:
+  - name: hue
+    newName: quay.io/opendatahub/hue
+    newTag: "4.8.0"
+  - name: mysql
+    newName: registry.redhat.io/rhel8/mariadb-103
+    newTag: latest
+  - name: mysqld-exporter
+    newName: quay.io/prometheus/mysqld-exporter
+    newTag: latest

--- a/hue/hue/base/params.env
+++ b/hue/hue/base/params.env
@@ -1,0 +1,5 @@
+storage_class=
+hue_secret_key=thisISaSECRET_1234
+s3_endpoint_url=
+s3_is_secure=true
+s3_credentials_secret=hue-sample-s3

--- a/hue/hue/base/params.yaml
+++ b/hue/hue/base/params.yaml
@@ -1,0 +1,12 @@
+---
+varReference:
+  - path: stringData/hue.ini
+    kind: Secret
+  - path: stringData/hive-site.xml
+    kind: Secret
+  - path: stringData/DATA_SOURCE_NAME
+    kind: Secret
+  - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class
+    kind: PersistentVolumeClaim
+  - path: spec/template/spec/containers[]/env[]/valueFrom/secretKeyRef/name
+    kind: Deployment

--- a/hue/hue/overlays/storage-class/kustomization.yaml
+++ b/hue/hue/overlays/storage-class/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      kind: PersistentVolumeClaim
+      version: v1
+      name: hue-mysql
+    path: pvc-patch.yaml

--- a/hue/hue/overlays/storage-class/pvc-patch.yaml
+++ b/hue/hue/overlays/storage-class/pvc-patch.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /metadata/annotations
+  value:
+    volume.beta.kubernetes.io/storage-class: "$(storage_class)"

--- a/tests/basictests/hue.sh
+++ b/tests/basictests/hue.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function test_hue() {
+    header "Testing ODH Hue installation"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    os::cmd::try_until_text "oc get deployment hue" "hue" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -l deployment=hue --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "hue" $odhdefaulttimeout $odhdefaultinterval
+    runningpods=($(oc get pods -l deployment=hue --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+}
+
+test_hue
+
+os::test::junit::declare_suite_end

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -97,6 +97,11 @@ spec:
         name: manifests
         path: odhargo/odhargo
     name: odhargo
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: hue/hue
+    name: hue
   # strimzi/kafka moved to bottom due to strange slowness in our test cluster
   # moving it down in the order seems to avoid the slowness
   - kustomizeConfig:


### PR DESCRIPTION
Adding Hue component Data catalog.

Part of: https://github.com/opendatahub-io/odh-manifests/issues/222, https://github.com/opendatahub-io/odh-manifests/issues/105, [DATAHUB-2294](https://projects.engineering.redhat.com/browse/DATAHUB-2294)

Based on reference implementation in https://github.com/AICoE/idh-manifests/pull/27 for Internal DH.

It will need further cleanup and extraction of parts into overlays later on (storage class, externalize the database). This is expected to happen in consecutive PRs.