### PR TITLE
feat(data-catalog): Adding Thriftserver

### DIFF
--- a/tests/basictests/thriftserver.sh
+++ b/tests/basictests/thriftserver.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function test_thriftserver() {
+    header "Testing ODH Hue installation"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+    os::cmd::try_until_text "oc get deployment thriftserver" "thriftserver" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "oc get pods -l deployment=thriftserver --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "thriftserver" $odhdefaulttimeout $odhdefaultinterval
+    runningpods=($(oc get pods -l deployment=thriftserver --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+}
+
+test_thriftserver
+
+os::test::junit::declare_suite_end

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -102,6 +102,13 @@ spec:
         name: manifests
         path: hue/hue
     name: hue
+  - kustomizeConfig:
+      overlays:
+        - create-spark-cluster
+      repoRef:
+        name: manifests
+        path: thriftserver/thriftserver
+    name: thriftserver
   # strimzi/kafka moved to bottom due to strange slowness in our test cluster
   # moving it down in the order seems to avoid the slowness
   - kustomizeConfig:

--- a/thriftserver/README.md
+++ b/thriftserver/README.md
@@ -1,0 +1,73 @@
+# Spark Thrift Server - HiveServer2
+
+Spark Thrift Server component installs HiveServer2 variant for Spark SQL - Thriftserver. It deploys the Spark SQL Thrift Server intended to expose Spark dataframes modeled as Hive tables through a JDBC connection.
+
+### Folders
+
+There is one main folder in the Thrift Server component `thriftserver` which contains the kustomize manifests.
+
+### Installation
+
+To install Thrift Server add the following to the `kfctl` yaml file.
+
+Minimal install:
+
+```yaml
+- kustomizeConfig:
+    parameters:
+      - name: spark_url
+        value: spark://spark.odh.com
+    repoRef:
+      name: manifests
+      path: thriftserver/thriftserver
+  name: thriftserver
+```
+
+Standalone install:
+
+```yaml
+- kustomizeConfig:
+    overlays:
+      - create-spark-cluster
+    parameters:
+      - name: s3_endpoint_url
+        value: s3.odh.com
+      - name: s3_credentials_secret
+        value: s3-credentials
+    repoRef:
+      name: manifests
+      path: thriftserver/thriftserver
+  name: thriftserver
+```
+
+### Overlays
+
+Thrift Server component comes with 2 overlays.
+
+#### storage-class
+
+Customizes Thrift Server to use a specific `StorageClass` for PVCs, see `storage_class` parameter.
+
+#### create-spark-cluster
+
+Requires `radanalytics/spark` component of ODH to be installed first. It provisions a minimal Spark cluster matching the Thrift Server's Spark version and connects the Thrift Server instance to it as it's master Spark cluster. This overlay modifies value of `spark_url` parameter and routes Thrift server to the Spark cluster created by this overlay only.
+
+### Parameters
+
+There are 4 parameters exposed vie KFDef.
+
+#### storage_class
+
+Name of the storage class to be used for PVCs created by Thrift Server component. This requires `storage-class` **overlay** to be enabled as well to work.
+
+#### s3_endpoint_url
+
+HTTP endpoint exposed by your S3 object storage solution which will be made available to Thrift Server as the default S3 filesystem location. In order for this value to be respected properly, the Spark cluster of choice must use the same endpoint.
+
+#### spark_url
+
+Spark cluster [`master-url`](https://spark.apache.org/docs/latest/submitting-applications.html#master-urls) in format `spark://...` which points Thrift Server to Spark cluster which it should use. This parameter value is **overriden** if `create-spark-cluster` overlay is activated. This parameter **is required** to be set if the overlay mentioned before is not used.
+
+#### s3_credentials_secret
+
+Along with `s3_endpoint_url` this parameter configures the Thrift Server's access to S3 object storage. Setting this parameter to any name of local Openshift/Kubernetes Secret resource name would allow Thift Server to consume S3 credentials from it. The secret of choice must contain `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` keys. Keep in mind, in order for this value to be respected by Spark cluster properly, it must use the same credentials. If not set, credentials from [`thriftserver-sample-s3-secret`](thriftserver/base/thriftserver-sample-s3-secret.yaml) will be used instead.

--- a/thriftserver/thriftserver/base/kustomization.yaml
+++ b/thriftserver/thriftserver/base/kustomization.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - thriftserver-db-exporter.yaml
+  - thriftserver-db-pvc.yaml
+  - thriftserver-db-secret.yaml
+  - thriftserver-db-service.yaml
+  - thriftserver-db.yaml
+  - thriftserver-hdfs-hive-secret.yaml
+  - thriftserver-pvc.yaml
+  - thriftserver-route.yaml
+  - thriftserver-sample-s3-secret.yaml
+  - thriftserver-server-conf-secret.yaml
+  - thriftserver-service.yaml
+  - thriftserver.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: thriftserver
+  component.opendatahub.io/part-of: datacatalog
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+configMapGenerator:
+  - name: thriftserver-config
+    envs:
+      - params.env
+
+vars:
+  - name: namespace
+    objref:
+      kind: Service
+      apiVersion: v1
+      name: thriftserver
+    fieldref:
+      fieldpath: metadata.namespace
+  - name: storage_class
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: thriftserver-config
+    fieldref:
+      fieldpath: data.storage_class
+  - name: spark_url
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: thriftserver-config
+    fieldref:
+      fieldpath: data.spark_url
+  - name: s3_endpoint_url
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: thriftserver-config
+    fieldref:
+      fieldpath: data.s3_endpoint_url
+  - name: s3_credentials_secret
+    objref:
+      kind: ConfigMap
+      apiVersion: v1
+      name: thriftserver-config
+    fieldref:
+      fieldpath: data.s3_credentials_secret
+  - name: database_user
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: thriftserver-db
+    fieldref:
+      fieldpath: stringData.database-user
+  - name: database_password
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: thriftserver-db
+    fieldref:
+      fieldpath: stringData.database-password
+  - name: database_name
+    objref:
+      kind: Secret
+      apiVersion: v1
+      name: thriftserver-db
+    fieldref:
+      fieldpath: stringData.database-name
+
+configurations:
+  - params.yaml
+
+images:
+  - name: spark-cluster-image
+    newName: quay.io/opendatahub/spark-cluster-image
+    newTag: 2.4.3-h2.7
+  - name: postgresql
+    newName: registry.redhat.io/rhel8/postgresql-12
+    newTag: latest
+  - name: postgres-exporter
+    newName: quay.io/internaldatahub/postgres_exporter
+    newTag: latest

--- a/thriftserver/thriftserver/base/params.env
+++ b/thriftserver/thriftserver/base/params.env
@@ -1,0 +1,4 @@
+storage_class=
+s3_endpoint_url=
+spark_url=
+s3_credentials_secret=thriftserver-sample-s3

--- a/thriftserver/thriftserver/base/params.yaml
+++ b/thriftserver/thriftserver/base/params.yaml
@@ -1,0 +1,10 @@
+---
+varReference:
+  - path: stringData/thrift-server.conf
+    kind: Secret
+  - path: stringData/DATA_SOURCE_NAME
+    kind: Secret
+  - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class
+    kind: PersistentVolumeClaim
+  - path: spec/template/spec/containers[]/env[]/valueFrom/secretKeyRef/name
+    kind: Deployment

--- a/thriftserver/thriftserver/base/thriftserver-db-exporter.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-db-exporter.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thriftserver-db-exporter
+  labels:
+    name: thriftserver-db-exporter
+stringData:
+  DATA_SOURCE_NAME: |
+    postgresql://$(database_user):$(database_password)@localhost:5432/$(database_name)?sslmode=disable

--- a/thriftserver/thriftserver/base/thriftserver-db-pvc.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-db-pvc.yaml
@@ -1,0 +1,11 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: thriftserver-db
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/thriftserver/thriftserver/base/thriftserver-db-secret.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-db-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thriftserver-db
+stringData:
+  database-user: datacatalog
+  database-password: datacatalog
+  database-name: datacatalog

--- a/thriftserver/thriftserver/base/thriftserver-db-service.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-db-service.yaml
@@ -1,0 +1,24 @@
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: thriftserver-db
+  annotations:
+    template.openshift.io/expose-uri: |
+      postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgres")].port}
+spec:
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      targetPort: 5432
+    - name: exporter
+      protocol: TCP
+      port: 9187
+      targetPort: 9187
+  selector:
+    deployment: thriftserver-db
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}

--- a/thriftserver/thriftserver/base/thriftserver-db.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-db.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thriftserver-db
+  annotations:
+    template.alpha.openshift.io/wait-for-ready: "true"
+spec:
+  replicas: 1
+  selector:
+    deployment: thriftserver-db
+  template:
+    metadata:
+      labels:
+        deployment: thriftserver-db
+    spec:
+      containers:
+        - name: postgres-exporter
+          image: postgres-exporter
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9187
+          env:
+            - name: DATA_SOURCE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: thriftserver-db-exporter
+                  key: DATA_SOURCE_NAME
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 9187
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 9187
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+            limits:
+              cpu: 200m
+              memory: 300Mi
+        - name: postgresql
+          image: postgresql
+          ports:
+            - containerPort: 5432
+          readinessProbe:
+            timeoutSeconds: 1
+            initialDelaySeconds: 5
+            exec:
+              command:
+                - "/usr/libexec/check-container"
+          livenessProbe:
+            timeoutSeconds: 10
+            initialDelaySeconds: 120
+            exec:
+              command:
+                - "/usr/libexec/check-container"
+                - "--live"
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: thriftserver-db
+                  key: database-user
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: thriftserver-db
+                  key: database-password
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: thriftserver-db
+                  key: database-name
+          resources:
+            requests:
+              cpu: 300m
+              memory: 500Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - name: "postgresql-data"
+              mountPath: "/var/lib/pgsql/data"
+          terminationMessagePath: "/dev/termination-log"
+          imagePullPolicy: IfNotPresent
+          capabilities: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+      volumes:
+        - name: "postgresql-data"
+          persistentVolumeClaim:
+            claimName: thriftserver-db
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst

--- a/thriftserver/thriftserver/base/thriftserver-hdfs-hive-secret.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-hdfs-hive-secret.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thriftserver-hdfs-hive
+stringData:
+  hdfs-site.xml: |-
+    <?xml version="1.0"?>
+    <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+    <configuration>
+      <property>
+        <name>hadoop.proxyuser.hue.hosts</name>
+        <value>*</value>
+      </property>
+
+      <property>
+        <name>hadoop.proxyuser.hue.groups</name>
+        <value>*</value>
+      </property>
+    </configuration>

--- a/thriftserver/thriftserver/base/thriftserver-pvc.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-pvc.yaml
@@ -1,0 +1,11 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: thriftserver
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: "5Gi"

--- a/thriftserver/thriftserver/base/thriftserver-route.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-route.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: thriftserver
+spec:
+  port:
+    targetPort: 4040-tcp
+  to:
+    kind: Service
+    name: thriftserver
+    weight: 100
+  wildcardPolicy: None

--- a/thriftserver/thriftserver/base/thriftserver-sample-s3-secret.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-sample-s3-secret.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thriftserver-sample-s3
+stringData:
+  AWS_ACCESS_KEY_ID: SECRET_KEY_ID
+  AWS_SECRET_ACCESS_KEY: SECRET_ACCESS_KEY

--- a/thriftserver/thriftserver/base/thriftserver-server-conf-secret.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-server-conf-secret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: thriftserver-server-conf
+stringData:
+  thrift-server.conf: |-
+    spark.blockManager.port=42100
+    spark.cores.max=2
+    spark.driver.bindAddress=0.0.0.0
+    spark.driver.host=thriftserver.$(namespace).svc
+    spark.driver.memory=2G
+    spark.driver.port=42000
+    spark.executor.memory=2G
+    spark.hadoop.datanucleus.rdbms.datastoreAdapterClassName=org.datanucleus.store.rdbms.adapter.PostgreSQLAdapter
+    spark.hadoop.datanucleus.schema.autoCreateAll=true
+    spark.hadoop.fs.s3a.endpoint=$(s3_endpoint_url)
+    spark.hadoop.fs.s3a.aws.credentials.provider=com.amazonaws.auth.EnvironmentVariableCredentialsProvider
+    spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
+    spark.hadoop.javax.jdo.option.ConnectionDriverName=org.postgresql.Driver
+    spark.hadoop.javax.jdo.option.ConnectionPassword=$(database_password)
+    spark.hadoop.javax.jdo.option.ConnectionURL=jdbc:postgresql://thriftserver-db.$(namespace).svc:5432/$(database_name)
+    spark.hadoop.javax.jdo.option.ConnectionUserName=$(database_user)
+    spark.sql.adaptive.enabled=true
+    spark.sql.thriftServer.incrementalCollect=true
+    spark.sql.warehouse.dir=/spark-warehouse

--- a/thriftserver/thriftserver/base/thriftserver-service.yaml
+++ b/thriftserver/thriftserver/base/thriftserver-service.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: thriftserver
+spec:
+  selector:
+    deployment: thriftserver
+  type: NodePort
+  ports:
+    - name: 10000-tcp
+      port: 10000
+      protocol: TCP
+      targetPort: 10000
+    - name: 4040-tcp
+      port: 4040
+      protocol: TCP
+      targetPort: 4040
+    - name: 42000-tcp
+      port: 42000
+      protocol: TCP
+      targetPort: 42000
+    - name: 42100-tcp
+      port: 42100
+      protocol: TCP
+      targetPort: 42100

--- a/thriftserver/thriftserver/base/thriftserver.yaml
+++ b/thriftserver/thriftserver/base/thriftserver.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thriftserver
+spec:
+  replicas: 1
+  selector:
+    deployment: thriftserver
+  template:
+    metadata:
+      labels:
+        deployment: thriftserver
+    spec:
+      containers:
+        - name: thriftserver
+          image: spark-cluster-image
+          args:
+            - "/opt/spark/bin/spark-class"
+            - "org.apache.spark.deploy.SparkSubmit"
+            - "--class"
+            - "org.apache.spark.sql.hive.thriftserver.HiveThriftServer2"
+            - "--properties-file"
+            - "/etc/spark-properties/thrift-server.conf"
+            - "--master"
+            - "$(SPARK_MASTER)"
+          imagePullPolicy: Always
+          env:
+            - name: SPARK_MASTER
+              valueFrom:
+                configMapKeyRef:
+                  name: thriftserver-config
+                  key: spark_url
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_ACCESS_KEY_ID
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: $(s3_credentials_secret)
+                  key: AWS_SECRET_ACCESS_KEY
+          volumeMounts:
+            - name: spark-conf
+              mountPath: /etc/spark-properties
+            - name: thriftserver-data
+              mountPath: /spark-warehouse
+            - name: thriftserver-hdfs-hive
+              mountPath: /opt/spark/conf
+          resources:
+            limits:
+              cpu: "2"
+              memory: 4Gi
+            requests:
+              cpu: 400m
+              memory: 1Gi
+          ports:
+            - containerPort: 4040
+            - containerPort: 10000
+            - containerPort: 42000
+            - containerPort: 42100
+          livenessProbe:
+            failureThreshold: 4
+            httpGet:
+              path: /api/v1/version
+              port: 4040
+              scheme: HTTP
+            periodSeconds: 30
+            initialDelaySeconds: 300
+            successThreshold: 1
+            timeoutSeconds: 5
+      restartPolicy: Always
+      volumes:
+        - name: thriftserver-hdfs-hive
+          secret:
+            secretName: thriftserver-hdfs-hive
+            items:
+              - key: hdfs-site.xml
+                path: hdfs-site.xml
+        - name: spark-conf
+          secret:
+            secretName: thriftserver-server-conf
+            items:
+              - key: thrift-server.conf
+                path: thrift-server.conf
+        - name: thriftserver-data
+          persistentVolumeClaim:
+            claimName: thriftserver

--- a/thriftserver/thriftserver/overlays/create-spark-cluster/kustomization.yaml
+++ b/thriftserver/thriftserver/overlays/create-spark-cluster/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+resources:
+  - spark-cluster.yaml
+
+patchesJson6902:
+  - path: thriftserver-config-patch.yaml
+    target:
+      kind: ConfigMap
+      name: thriftserver-config
+      version: v1
+
+configurations:
+  - params.yaml
+
+commonLabels:
+  opendatahub.io/component: "true"
+  component.opendatahub.io/name: thriftserver
+  component.opendatahub.io/part-of: datacatalog
+
+images:
+  - name: spark-cluster-image
+    newName: quay.io/opendatahub/spark-cluster-image
+    newTag: 2.4.3-h2.7

--- a/thriftserver/thriftserver/overlays/create-spark-cluster/params.yaml
+++ b/thriftserver/thriftserver/overlays/create-spark-cluster/params.yaml
@@ -1,0 +1,8 @@
+---
+varReference:
+  - path: data/spark_url
+    kind: ConfigMap
+
+images:
+  - path: spec/customImage
+    kind: SparkCluster

--- a/thriftserver/thriftserver/overlays/create-spark-cluster/spark-cluster.yaml
+++ b/thriftserver/thriftserver/overlays/create-spark-cluster/spark-cluster.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: radanalytics.io/v1
+kind: SparkCluster
+metadata:
+  name: spark-cluster-thriftserver
+spec:
+  worker:
+    instances: "1"
+    memoryRequest: 512Mi
+    memoryLimit: 2Gi
+    cpuRequest: 200m
+    cpuLimit: "2"
+  master:
+    instances: "1"
+    memoryRequest: 512Mi
+    memoryLimit: 2Gi
+    cpuRequest: 200m
+    cpuLimit: "2"
+  customImage: spark-cluster-image
+  env:
+    - name: SPARK_METRICS_ON # Requires quay.io/radanalyticsio/openshift-spark-py36 image or compatible
+      value: prometheus

--- a/thriftserver/thriftserver/overlays/create-spark-cluster/thriftserver-config-patch.yaml
+++ b/thriftserver/thriftserver/overlays/create-spark-cluster/thriftserver-config-patch.yaml
@@ -1,0 +1,4 @@
+---
+- op: replace
+  path: /data/spark_url
+  value: spark://spark-cluster-thriftserver.$(namespace).svc:7077

--- a/thriftserver/thriftserver/overlays/storage-class/kustomization.yaml
+++ b/thriftserver/thriftserver/overlays/storage-class/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      kind: PersistentVolumeClaim
+      version: v1
+      name: thriftserver-db
+    path: pvc-patch.yaml
+  - target:
+      kind: PersistentVolumeClaim
+      version: v1
+      name: thriftserver
+    path: pvc-patch.yaml

--- a/thriftserver/thriftserver/overlays/storage-class/pvc-patch.yaml
+++ b/thriftserver/thriftserver/overlays/storage-class/pvc-patch.yaml
@@ -1,0 +1,5 @@
+---
+- op: add
+  path: /metadata/annotations
+  value:
+    volume.beta.kubernetes.io/storage-class: "$(storage_class)"


### PR DESCRIPTION
Adding Thriftserver component Data catalog.

Part of: https://github.com/opendatahub-io/odh-manifests/issues/222, https://github.com/opendatahub-io/odh-manifests/issues/105, [DATAHUB-2294](https://projects.engineering.redhat.com/browse/DATAHUB-2294)

Based on reference implementation in https://github.com/AICoE/idh-manifests/pull/29 for Internal DH.

It will need further cleanup and extraction of parts into overlays later on (storage class, externalize the database). This is expected to happen in consecutive PRs.