### PR TITLE
Checking for test success before saving our logs

### DIFF
--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -27,7 +27,14 @@ if [ -z "${SKIP_INSTALL}" ]; then
     echo "Sleeping for 5 min to let the KfDef install settle"
     sleep 5m
 fi
+
+success=1
 $HOME/peak/run.sh ${TESTS_REGEX}
+
+if  [ "$?" -ne 0 ]; then
+    echo "The tests failed"
+    success=0
+fi
 
 echo "Saving the dump of the pods logs in the artifacts directory"
 oc get pods -o yaml -n ${ODHPROJECT} > ${ARTIFACT_DIR}/${ODHPROJECT}.pods.yaml
@@ -35,10 +42,11 @@ echo "Saving the logs from the opendatahub-operator pod in the artifacts directo
 oc logs -n openshift-operators $(oc get pods -n openshift-operators -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/opendatahub-operator.log 2> /dev/null || echo "No logs for openshift-operators/opendatahub-operator"
 oc logs -n opendatahub-operator $(oc get pods -n opendatahub-operator -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/odh-operator.log 2> /dev/null || echo "No logs for opendatahub-operator/opendatahub-operator"
 
-if  [ "$?" -ne 0 ]; then
-    echo "The tests failed"
+if [ "$success" -ne 1 ]; then
     exit 1
 fi
+
+
 
 ## Debugging pause...uncomment below to be able to poke around the test pod post-test
 # echo "Debugging pause for 3 hours"


### PR DESCRIPTION
Need to save the success value immediately after the run.sh call so we can exit with the proper code after dumping our logs.