### PR TITLE
Update odh-dashboard deployment imagePullPolicy to "Always"

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -16,6 +16,7 @@ spec:
       containers:
       - name: odh-dashboard
         image: quay.io/opendatahub/odh-dashboard:v0.9
+        imagePullPolicy: Always
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
Added `imagePullPolicy: Always` so the deployment would pick up newer image marked with the `v0.9` tag