### PR TITLE
WIP: Add registry parameters for JH to support disconnected install

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -11,7 +11,7 @@ Contains deployment manifests for JupyterHub instance.
 
 ### Parameters
 
-JupyterHub component comes with 2 parameters exposed vie KFDef.
+JupyterHub component comes with 4 parameters exposed vie KFDef.
 
 #### s3_endpoint_url
 
@@ -20,6 +20,14 @@ HTTP endpoint exposed by your S3 object storage solution which will be made avai
 #### storage_class
 
 Name of the storage class to be used for PVCs created by JupyterHub component. This requires `storage-class` **overlay** to be enabled as well to work.
+
+#### registry
+
+URL of the registry where images are located. This is useful when you are trying to deploy to a disconnected/air gapped cluster where images are mirrored to some local registry.
+
+#### registry_db
+
+Same as `registry` but specifically used for the DB deployment since that is pulled from a different registry than the rest of the images by default
 
 ##### Examples
 
@@ -57,7 +65,11 @@ Contains manifests for Jupyter notebook images compatible with JupyterHub on Ope
 
 ### Parameters
 
-Notebook Images do not provide any parameters.
+Notebook images come with 1 parameter
+
+#### registry
+
+URL of the registry where images are located. This is useful when you are trying to deploy to a disconnected/air gapped cluster where images are mirrored to some local registry.
 
 ### Overlays
 

--- a/jupyterhub/jupyterhub/base/jupyterhub-db-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-db-dc.yaml
@@ -22,7 +22,7 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-      - image: registry.redhat.io/rhel8/postgresql-96
+      - image: $(registry_db)/rhel8/postgresql-96
         env:
         - name: POSTGRESQL_USER
           valueFrom:

--- a/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
@@ -8,10 +8,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/jupyterhub-img
+      openshift.io/imported-from: $(registry)/odh-jupyterhub/jupyterhub-img
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/jupyterhub-img:v0.1.4
+      name: $(registry)/odh-jupyterhub/jupyterhub-img:v0.1.4
     name: latest
     referencePolicy:
       type: Source

--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -51,7 +51,7 @@ data:
               worker_cpu_limit: '1'
               worker_memory_request: '2Gi'
               worker_cpu_request: '1'
-              spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
+              spark_image: '$(registry)/radanalyticsio/openshift-spark-py36:2.4.5-2'
             return:
               SPARK_CLUSTER: 'metadata.name'
 

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -47,5 +47,19 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.s3_endpoint_url
+- name: registry
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.registry
+- name: registry_db
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.registry_db
 configurations:
 - params.yaml

--- a/jupyterhub/jupyterhub/base/params.env
+++ b/jupyterhub/jupyterhub/base/params.env
@@ -1,2 +1,4 @@
 storage_class=
 s3_endpoint_url=
+registry=quay.io
+registry_db=registry.redhat.io

--- a/jupyterhub/jupyterhub/base/params.yaml
+++ b/jupyterhub/jupyterhub/base/params.yaml
@@ -6,3 +6,9 @@ varReference:
   kind: ConfigMap
 - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class
   kind: PersistentVolumeClaim
+- path: spec/tags/from/name
+  kind: ImageStream
+- path: spec/tags/annotations/openshift.io\/imported-from
+  kind: ImageStream
+- path: spec/template/spec/containers/image
+  kind: DeploymentConfig

--- a/jupyterhub/notebook-images/base/kustomization.yaml
+++ b/jupyterhub/notebook-images/base/kustomization.yaml
@@ -7,3 +7,20 @@ resources:
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: jupyterhub
+
+
+configMapGenerator:
+- name: jupyterhub-notebook-parameters
+  env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: registry
+  objref:
+    kind: ConfigMap
+    name: jupyterhub-notebook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.registry
+configurations:
+- params.yaml

--- a/jupyterhub/notebook-images/base/nbviewer-imagestream.yaml
+++ b/jupyterhub/notebook-images/base/nbviewer-imagestream.yaml
@@ -8,10 +8,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/nbviewer
+      openshift.io/imported-from: $(registry)/odh-jupyterhub/nbviewer
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/nbviewer:latest
+      name: $(registry)/odh-jupyterhub/nbviewer:latest
     name: latest
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/base/params.env
+++ b/jupyterhub/notebook-images/base/params.env
@@ -1,0 +1,1 @@
+registry=quay.io

--- a/jupyterhub/notebook-images/base/params.yaml
+++ b/jupyterhub/notebook-images/base/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: spec/tags/from/name
+  kind: ImageStream
+- path: spec/tags/annotations/openshift.io\/imported-from
+  kind: ImageStream

--- a/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
@@ -9,10 +9,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-spark-minimal-notebook
+      openshift.io/imported-from: $(registry)/odh-jupyterhub/s2i-spark-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3
+      name: $(registry)/odh-jupyterhub/s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3
     name: "py36-spark2.4.5-hadoop2.7.3"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -13,10 +13,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
+      openshift.io/imported-from: $(registry)/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.5
+      name: $(registry)/thoth-station/s2i-lab-elyra:v0.0.5
     name: "v0.0.5"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -13,10 +13,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-notebook
+      openshift.io/imported-from: $(registry)/thoth-station/s2i-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+      name: $(registry)/thoth-station/s2i-minimal-notebook:v0.0.4
     name: "v0.0.4"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
@@ -13,10 +13,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/thoth-station/s2i-scipy-notebook
+      openshift.io/imported-from: $(registry)/thoth-station/s2i-scipy-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-scipy-notebook:v0.0.1
+      name: $(registry)/thoth-station/s2i-scipy-notebook:v0.0.1
     name: "v0.0.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
@@ -9,10 +9,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/odh-jupyterhub/s2i-spark-scipy-notebook
+      openshift.io/imported-from: $(registry)/odh-jupyterhub/s2i-spark-scipy-notebook
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/s2i-spark-scipy-notebook:3.6
+      name: $(registry)/odh-jupyterhub/s2i-spark-scipy-notebook:3.6
     name: "3.6"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -13,10 +13,10 @@ spec:
     local: true
   tags:
   - annotations:
-      openshift.io/imported-from: quay.io/thoth-station/s2i-tensorflow-notebook
+      openshift.io/imported-from: $(registry)/thoth-station/s2i-tensorflow-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1
+      name: $(registry)/thoth-station/s2i-tensorflow-notebook:v0.0.1
     name: "v0.0.1"
     referencePolicy:
       type: Source

--- a/kfdef/kfctl_openshift_disconnected.yaml
+++ b/kfdef/kfctl_openshift_disconnected.yaml
@@ -1,0 +1,34 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: opendatahub
+  namespace: opendatahub
+spec:
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: odh-common
+    name: odh-common
+  - kustomizeConfig:
+      parameters:
+        - name: s3_endpoint_url
+          value: "s3.odh.com"
+      repoRef:
+        name: manifests
+        path: jupyterhub/jupyterhub
+    name: jupyterhub
+  - kustomizeConfig:
+      overlays:
+      #- cuda
+      - additional
+      repoRef:
+        name: manifests
+        path: jupyterhub/notebook-images
+    name: notebook-images
+  repos:
+  - name: kf-manifests
+    uri: https://github.com/opendatahub-io/manifests/tarball/v1.0-branch-openshift
+  - name: manifests
+    uri: https://github.com/vpavlin/odh-manifests/tarball/feature/disconnected-jupyterhub
+  version: v0.7-branch-openshift


### PR DESCRIPTION
This implements part of #15.

Specifically it adds parameter `registry` and `registry_db` for JH components which allow users to specify the registry where the images for the component should be pulled from (by default `quay.io` and `registry.redhat.io`)

PTAL @carlmes

