### PR TITLE
feat: Add Argo updater script and maintainer docs

### DIFF
--- a/odhargo/gen_argo_manifests.sh
+++ b/odhargo/gen_argo_manifests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eu -o pipefail
+
+echo -n ".. Fetching latest version"
+version=$(basename $(curl -Ls -o /dev/null -w %{url_effective} https://github.com/argoproj/argo/releases/latest))
+old_version=$(grep -oP '(?<=<!-- ).*(?= -->)' README.md)
+echo -e "\r ✓"
+echo "     Latest release: $version"
+
+echo -n ".. Temporarily cloning the upstream repo"
+tmp_dir=$(mktemp -d)
+git clone -c advice.detachedHead=false --quiet --depth 1 --branch $version https://github.com/argoproj/argo.git $tmp_dir > /dev/null
+echo -e "\r ✓"
+
+echo -n ".. Building CRDs"
+kustomize build "$tmp_dir/manifests/base/crds" > cluster/base/crds.yaml
+echo -e "\r ✓"
+
+echo -n ".. Copying ClusterRoles"
+cp "$tmp_dir/manifests/cluster-install/workflow-controller-rbac/workflow-aggregate-roles.yaml" cluster/base/cluster-roles.yaml
+echo -e "\r ✓"
+
+echo -n ".. Building namespaced resources"
+sed -i '/.*crds/d' "$tmp_dir/manifests/base/kustomization.yaml"
+kustomize build "$tmp_dir/manifests/namespace-install" > odhargo/base/namespace-install.yaml
+echo -e "\r ✓"
+
+echo -n ".. Update image tags in kustomization.yaml"
+sed -i "s/$old_version/$version/g" odhargo/base/kustomization.yaml
+echo -e "\r ✓"
+
+echo ".. Ensure the result is buildable"
+for folder in cluster/base odhargo/base; do
+    echo -n "  .. [$folder]"
+    kustomize build $folder > /dev/null && echo -e "\r   ✓"
+done
+
+echo -n ".. Removing the temporary clone"
+rm -rf $tmp_dir
+echo -e "\r ✓ "
+
+echo -n ".. Updating README version"
+sed -i "s/$old_version/$version/g" README.md
+echo -e "\r ✓ "

--- a/odhargo/maintainers.md
+++ b/odhargo/maintainers.md
@@ -1,0 +1,10 @@
+# ODH Argo guide for maintainers
+
+## Updating the component manifests
+
+Steps for semi-automated manifests update of Argo manifests in this repo:
+
+1. Execute the [`gen_argo_manifests.sh`](gen_argo_manifests.sh) script within this folder, which results in:
+   - Latest manifests are fetched
+   - `README` version banner updated
+2. Commit


### PR DESCRIPTION
Follow up to: https://github.com/opendatahub-io/odh-manifests/pull/208

This PR is separating the updater script into a new PR so we can have more fun with that bit and we don't block the actual manifests from merging. 

Context: https://github.com/opendatahub-io/odh-manifests/pull/208#discussion_r558079323