### PR TITLE
Fix tf gpu build param

### DIFF
--- a/jupyterhub/notebook-images/overlays/cuda/params.yaml
+++ b/jupyterhub/notebook-images/overlays/cuda/params.yaml
@@ -16,3 +16,5 @@ varReference:
   kind: BuildConfig
 - path: spec/strategy/dockerStrategy/from/name
   kind: BuildConfig
+- path: spec/strategy/sourceStrategy/from/name
+  kind: BuildConfig


### PR DESCRIPTION
This fixes an issue where the `cuda_version` parameter is not substituted in the `s2i-minimal-notebook-gpu` BuildConfig `sourceStrategy.from.name` field.

This is built on top of #264 and needs to be merged after it

To verify this PR, you can need to enable the `cuda` overlay in `notebook-images` and verify that the `s2i-minimal-notebook-gpu` buildConfig successfully parses the `cuda_version` var at `spec.strategy.sourceStrategy.from.name`