### PR TITLE
Use airflowui secure route for tests

### DIFF
--- a/tests/basictests/airflow.sh
+++ b/tests/basictests/airflow.sh
@@ -22,8 +22,8 @@ function test_routes(){
   header "Testing Flower and AirflowUI Routes"
   airflowuiroute=$(oc get route pc-cluster-airflowui -o jsonpath="{$.status.ingress[0].host}")
   flowerroute=$(oc get route pc-cluster-flower -o jsonpath="{$.status.ingress[0].host}")
-  os::cmd::try_until_text "curl -k http://$airflowuiroute/admin/" "Airflow - DAGs"
-  os::cmd::try_until_text "curl -k http://$flowerroute" "Flower"
+  os::cmd::try_until_text "curl -k https://$airflowuiroute/admin/" "Airflow - DAGs"
+  os::cmd::try_until_text "curl -k https://$flowerroute" "Flower"
 }
 
 function verify_airflow(){


### PR DESCRIPTION
Recent change to the airflow operator enables secure routes for the airflowui route. This PR switches the tests to use the secure route when testing against the airflowui

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>