### PR TITLE
Update grafana to version 3.8.1

### DIFF
--- a/grafana/cluster/base/subscription.yaml
+++ b/grafana/cluster/base/subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v3.6.0
+  startingCSV: grafana-operator.v3.8.1


### PR DESCRIPTION
3.8.0 crashes instantly.  This should yield a smoother install.