### PR TITLE
upgrade s2i notebook images for jupyterhub

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.4
+      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.7
     name: "v0.0.4"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-scipy-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-scipy-notebook:v0.0.1
+      name: quay.io/thoth-station/s2i-scipy-notebook:v0.0.2
     name: "v0.0.1"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-tensorflow-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.1
+      name: quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.2
     name: "v0.0.1"
     referencePolicy:
       type: Source


### PR DESCRIPTION
upgrade s2i notebook images for jupyterhub
Fixes: #303 
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

These upgrade images have updated versions of the jupyter core and other images, which caused an issue with jupyterhub shift to jupyterlab default.