### PR TITLE
Simplify test for dashboard pods, hopefully eliminating flake

### DIFF
--- a/tests/basictests/dashboard.sh
+++ b/tests/basictests/dashboard.sh
@@ -17,9 +17,7 @@ function check_resources() {
     os::cmd::try_until_text "oc get route odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
     os::cmd::try_until_text "oc get service odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
     os::cmd::try_until_text "oc get deployment odh-dashboard" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
-    os::cmd::try_until_text "oc get pods -l deployment=odh-dashboard --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "odh-dashboard" $odhdefaulttimeout $odhdefaultinterval
-    runningpods=($(oc get pods -l deployment=odh-dashboard --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
-    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "2"
+    os::cmd::try_until_text "oc get pods -l deployment=odh-dashboard --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}' | wc -w" "2" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function check_ui() {


### PR DESCRIPTION
Previously, the dashboard tests might fail if there was just one pod up and running instead of the expected 2.  This change should just repeat the call until there are exactly 2 pods up and running.