### PR TITLE
Use "Argo Workflows" instead of "Argo"

### DIFF
--- a/odhargo/README.md
+++ b/odhargo/README.md
@@ -1,14 +1,14 @@
 # ODH Argo
 
-![ODH Argo version](https://img.shields.io/badge/ODH_Argo_version-v2.12.5-yellow.svg) <!-- v2.12.5 -->
+![ODH Argo Workflows version](https://img.shields.io/badge/ODH_Argo_version-v2.12.5-yellow.svg) <!-- v2.12.5 -->
 ![Upstream version](https://img.shields.io/github/v/release/argoproj/argo?label=Upstream%20release)
 
-ODH Argo component installs Argo that is namespace bound and not cluster wide. There are two pods running after installation
+ODH Argo component installs Argo Workflows that is namespace bound and not cluster wide. There are two pods running after installation
 
 1. Argo Server
 2. Argo Controller
 
-This Argo installation uses the "k8sapi" executor to work on Openshift.
+This Argo Workflows installation uses the "k8sapi" executor to work on Openshift.
 
 ### Folders
 
@@ -18,11 +18,11 @@ This Argo installation uses the "k8sapi" executor to work on Openshift.
 
 ### Argo Server
 
-This installation creates a route to the Argo portal. To access the portal go to `Routes` and click on the `Argo Server` route.
+This installation creates a route to the Argo Workflows portal. To access the portal go to `Routes` and click on the `Argo Server` route.
 
 ### Installation
 
-To install Argo add the following to the `kfctl` yaml file.
+To install Argo Workflows add the following to the `kfctl` yaml file.
 
 ```yaml
 - kustomizeConfig:
@@ -49,7 +49,7 @@ metadata:
 spec: ...
 ```
 
-or submit it via [Argo CLI](https://github.com/argoproj/argo/releases):
+or submit it via [Argo Workflows CLI](https://github.com/argoproj/argo/releases):
 
 ```sh
 argo submit odhargo/base/test-workflow.yaml
@@ -57,4 +57,4 @@ argo submit odhargo/base/test-workflow.yaml
 
 ### Known issues
 
-- Argo UI raises 2 "Forbidden" notifications on initial page load. This is just a cosmetic issue and doesn't effect functionality. [argoproj/argo#4885](https://github.com/argoproj/argo/issues/4885)
+- Argo Workflows UI raises 2 "Forbidden" notifications on initial page load. This is just a cosmetic issue and doesn't effect functionality. [argoproj/argo#4885](https://github.com/argoproj/argo/issues/4885)


### PR DESCRIPTION
.. to be more explicit about which Argo project is being used.