### PR TITLE
Change ODH dashboard type to ClusterIP

### DIFF
--- a/odh-dashboard/base/service.yaml
+++ b/odh-dashboard/base/service.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   selector:
     deployment: odh-dashboard
-  type: LoadBalancer
   ports:
   - protocol: TCP
     targetPort: 8080


### PR DESCRIPTION
When set to "LoadBalancer", OpenShift will attempt to provision a cloud
provider's LoadBalancer instance (e.g. AWS ELB) to route traffic to the
pods. This is not necessary for us, and puts additional cost on the
users. This change deletes the type definition, so we'll use the default
type of "ClusterIP".