### PR TITLE
set imagestream name same as the tag version

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -17,6 +17,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.7
-    name: "v0.0.4"
+    name: "v0.0.7"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/scipy-notebook-imagestream.yaml
@@ -17,6 +17,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/thoth-station/s2i-scipy-notebook:v0.0.2
-    name: "v0.0.1"
+    name: "v0.0.2"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/tensorflow-notebook-imagestream.yaml
@@ -17,6 +17,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/thoth-station/s2i-tensorflow-notebook:v0.0.2
-    name: "v0.0.1"
+    name: "v0.0.2"
     referencePolicy:
       type: Source

--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -11,7 +11,7 @@ JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
 OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
 JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
 
-JUPYTER_IMAGES=(s2i-minimal-notebook:v0.0.4 s2i-scipy-notebook:v0.0.1 s2i-tensorflow-notebook:v0.0.1 s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3)
+JUPYTER_IMAGES=(s2i-minimal-notebook:v0.0.7 s2i-scipy-notebook:v0.0.2 s2i-tensorflow-notebook:v0.0.2 s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3)
 JUPYTER_NOTEBOOK_FILES=(basic.ipynb basic.ipynb tensorflow.ipynb spark.ipynb)
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"


### PR DESCRIPTION
Related-To: https://github.com/opendatahub-io/odh-manifests/pull/304

set imagestream name same as the tag version
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>