### PR TITLE
Remove tls-acme annotation from JuptyerHub route

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-route.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-route.yaml
@@ -1,8 +1,6 @@
 apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
-  annotations:
-    kubernetes.io/tls-acme: 'true'
   labels:
     app: jupyterhub
   name: jupyterhub


### PR DESCRIPTION
This annotation configures Kubernetes to automatically provision TLS
certificates for the JupyterHub route from Let's Encrypt. In my opinion,
we should rely on OpenShift-provisioned certs by default and let users
override this as they need, whether that means ACME or something else.