### PR TITLE
Add OpenShift Pipelines component

### DIFF
--- a/openshift-pipelines/README.md
+++ b/openshift-pipelines/README.md
@@ -1,0 +1,72 @@
+# OpenShift Pipelines
+
+[OpenShift Pipelines](https://www.openshift.com/learn/topics/pipelines) enables pipelines on OpenShift based on Red Hat's implementation of [Tekton](https://tekton.dev)
+ 
+### Folders
+There is one main folder in the OpenShift Pipelines component
+1. cluster: contains the subscription to the OpenShift Pipelines operator
+
+
+### Installation
+To install OpenShift Pipelines add the following to the `kfctl` yaml file.
+
+```
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: openshift-operators
+      repoRef:
+        name: manifests
+        path: openshift-pipelines/cluster
+    name: openshift-pipelines
+```
+
+### Example
+1. Create a Task that can be included in a Pipeline step
+   ```
+   apiVersion: tekton.dev/v1beta1
+   kind: Task
+   metadata:
+     name: hello-world
+   spec:
+     params:
+       - name: subject
+         description: name of person to greet
+         default: ODH
+         type: string
+     steps:
+       - name: hello-world
+         image: registry.access.redhat.com/ubi8/ubi
+         command:
+           - echo
+         args:
+           - "$(params.subject), Hello World!"
+   ```
+
+1. Create the Pipeline that will include the hello-world task created above
+   ```
+   apiVersion: tekton.dev/v1beta1
+   kind: Pipeline
+   metadata:
+     name: hello-world
+   spec:
+     tasks:
+       - name: hello-world
+         params:
+           - name: subject
+             value: ODH Test
+         taskRef:
+           kind: Task
+           name: hello-world
+   ```
+
+1. Finally instantiate the pipeline by creating a PipelineRun.
+   ```
+   apiVersion: tekton.dev/v1beta1
+   kind: PipelineRun
+   metadata:
+     generateName: hello-world-
+   spec:
+     pipelineRef:
+       name: hello-world
+   ```

--- a/openshift-pipelines/cluster/base/kustomization.yaml
+++ b/openshift-pipelines/cluster/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: opendatahub
+resources:
+- subscription.yaml

--- a/openshift-pipelines/cluster/base/subscription.yaml
+++ b/openshift-pipelines/cluster/base/subscription.yaml
@@ -1,0 +1,12 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-pipelines-operator
+  namespace: openshift-operators
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  startingCSV: redhat-openshift-pipelines-operator.v1.2.3
+  name: openshift-pipelines-operator-rh
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/tests/basictests/openshift-pipelines.sh
+++ b/tests/basictests/openshift-pipelines.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+OPENSHIFT_PIPELINES_RESOURCES_DIR="${MY_DIR}/../resources/openshift-pipelines"
+TASK_CR="${OPENSHIFT_PIPELINES_RESOURCES_DIR}/task-hello-world.yaml"
+PIPELINE_CR="${OPENSHIFT_PIPELINES_RESOURCES_DIR}/pipeline-hello-world.yaml"
+PIPELINERUN_CR="${OPENSHIFT_PIPELINES_RESOURCES_DIR}/pipelinerun-hello-world.yaml"
+
+function verify_openshift_pipelines_operator_install() {
+    header "Testing OpenShift Pipelines operator installation"
+    os::cmd::expect_success_and_text "oc get deployment -n openshift-operators openshift-pipelines-operator" "openshift-pipelines-operator"
+    runningpods=($(oc get pods -n openshift-operators -l name=openshift-pipelines-operator --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+}
+
+function create_openshift_pipelines_objects() {
+    header "Create OpenShift Pipelines"
+    os::cmd::expect_success "oc apply -f ${TASK_CR}"
+    os::cmd::try_until_not_text "oc get task odh-test-hello-world" "not found"
+
+    os::cmd::expect_success "oc apply -f ${PIPELINE_CR}"
+    os::cmd::try_until_not_text "oc get pipeline odh-test-hello-world" "not found"
+
+    os::cmd::expect_success "oc create -f ${PIPELINERUN_CR}"
+}
+
+function test_openshift_pipelines_functionality() {
+    header "Testing OpenShift Pipelines functionality"
+    os::cmd::expect_success "oc project ${ODHPROJECT}"
+
+    verify_openshift_pipelines_operator_install
+    create_openshift_pipelines_objects
+
+}
+
+test_openshift_pipelines_functionality
+
+os::test::junit::declare_suite_end

--- a/tests/resources/openshift-pipelines/pipeline-hello-world.yaml
+++ b/tests/resources/openshift-pipelines/pipeline-hello-world.yaml
@@ -1,0 +1,13 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: odh-test-hello-world
+spec:
+  tasks:
+    - name: odh-test-hello-world
+      params:
+        - name: subject
+          value: ODH Test
+      taskRef:
+        kind: Task
+        name: odh-test-hello-world

--- a/tests/resources/openshift-pipelines/pipelinerun-hello-world.yaml
+++ b/tests/resources/openshift-pipelines/pipelinerun-hello-world.yaml
@@ -1,0 +1,7 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  generateName: odh-test-hello-world-
+spec:
+  pipelineRef:
+    name: odh-test-hello-world

--- a/tests/resources/openshift-pipelines/task-hello-world.yaml
+++ b/tests/resources/openshift-pipelines/task-hello-world.yaml
@@ -1,0 +1,17 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: odh-test-hello-world
+spec:
+  params:
+    - name: subject
+      description: name of person to greet
+      default: ODH
+      type: string
+  steps:
+    - name: hello-world
+      image: registry.access.redhat.com/ubi8/ubi
+      command:
+        - echo
+      args:
+        - "$(params.subject), Hello World!"

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -129,9 +129,17 @@ spec:
         name: manifests
         path: odh-dashboard
     name: odh-dashboard
+  - kustomizeConfig:
+      parameters:
+        - name: namespace
+          value: openshift-operators
+      repoRef:
+        name: manifests
+        path: openshift-pipelines/cluster
+    name: openshift-pipelines
   repos:
   - name: kf-manifests
-    uri: https://github.com/opendatahub-io/manifests/tarball/v0.7-branch-openshift  
+    uri: https://github.com/opendatahub-io/manifests/tarball/master
   - name: manifests
     uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
-  version: v0.7-branch-openshift
+  version: master


### PR DESCRIPTION
Adds `openshift-pipelines` (`tekton`) as a component that can be deployed in ODH. 

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>