### PR TITLE
Update Grafana Operator Version to 3.9.0

### DIFF
--- a/grafana/cluster/base/subscription.yaml
+++ b/grafana/cluster/base/subscription.yaml
@@ -9,4 +9,4 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v3.8.1
+  startingCSV: grafana-operator.v3.9.0


### PR DESCRIPTION
This will update the version of Grafana Operator to v3.9.0.
