### PR TITLE
Update JH image with prometheus authentication

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
@@ -11,7 +11,7 @@ spec:
       openshift.io/imported-from: quay.io/odh-jupyterhub/jupyterhub-img
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/jupyterhub-img:v0.2.0
+      name: quay.io/odh-jupyterhub/jupyterhub-img:v0.2.1
     name: latest
     referencePolicy:
       type: Source


### PR DESCRIPTION
Pull in the updated JH image that includes the changes from https://github.com/opendatahub-io/jupyterhub-odh/pull/77

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>