### PR TITLE
Add JH groups configuration CM

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -21,6 +21,10 @@ HTTP endpoint exposed by your S3 object storage solution which will be made avai
 
 Name of the storage class to be used for PVCs created by JupyterHub component. This requires `storage-class` **overlay** to be enabled as well to work.
 
+#### jupyterhub_groups_config
+
+A ConfigMap containing comma separated lists of groups which would be used as Admin and User groups for JupyterHub. The default ConfgiMap can be found [here](jupyterhub/base/jupyterhub-groups-configmap.yaml).
+
 ##### Examples
 
 ```

--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -63,6 +63,16 @@ spec:
             configMapKeyRef:
               name: jupyterhub-cfg
               key: singleuser_pvc_size
+        - name: JUPYTERHUB_ADMIN_GROUPS
+          valueFrom:
+            configMapKeyRef:
+              name: $(jupyterhub_groups_config)
+              key: admin_groups
+        - name: JUPYTERHUB_ALLOWED_GROUPS
+          valueFrom:
+            configMapKeyRef:
+              name: $(jupyterhub_groups_config)
+              key: allowed_groups
         image: jupyterhub-img:latest
         name: jupyterhub
         ports:

--- a/jupyterhub/jupyterhub/base/jupyterhub-groups-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-groups-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+  name: jupyterhub-default-groups-config
+data:
+  admin_groups: ""
+  allowed_groups: ""

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
 - jupyterhub-route.yaml
 - jupyterhub-singleuser-profiles-configmap.yaml
 - jupyterhub-spark-operator-configmap.yaml
+- jupyterhub-groups-configmap.yaml
 
 commonLabels:
   opendatahub.io/component: "true"
@@ -47,5 +48,12 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.s3_endpoint_url
+- name: jupyterhub_groups_config
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.jupyterhub_groups_config
 configurations:
 - params.yaml

--- a/jupyterhub/jupyterhub/base/params.env
+++ b/jupyterhub/jupyterhub/base/params.env
@@ -1,2 +1,3 @@
 storage_class=
 s3_endpoint_url=
+jupyterhub_groups_config=jupyterhub-default-groups-config

--- a/jupyterhub/jupyterhub/base/params.yaml
+++ b/jupyterhub/jupyterhub/base/params.yaml
@@ -6,3 +6,5 @@ varReference:
   kind: ConfigMap
 - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class
   kind: PersistentVolumeClaim
+- path: spec/template/spec/containers/env/valueFrom/configMapKeyRef/name
+  kind: DeploymentConfig


### PR DESCRIPTION
This PR adds a configmap to set names of groups for JH users and admins

1. By default, no groups are used and anyone with OpenShift login have access to JH
2. User can provide a custom CM with groups listed and set the name of the CM as `parameter` - `jupyterhub_groups_config
`

The secret is then managed outside of the operator.

