### PR TITLE
Remove empty odh operator log artifact from tests runs

### DIFF
--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -40,7 +40,6 @@ echo "Saving the dump of the pods logs in the artifacts directory"
 oc get pods -o yaml -n ${ODHPROJECT} > ${ARTIFACT_DIR}/${ODHPROJECT}.pods.yaml
 echo "Saving the logs from the opendatahub-operator pod in the artifacts directory"
 oc logs -n openshift-operators $(oc get pods -n openshift-operators -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/opendatahub-operator.log 2> /dev/null || echo "No logs for openshift-operators/opendatahub-operator"
-oc logs -n opendatahub-operator $(oc get pods -n opendatahub-operator -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/odh-operator.log 2> /dev/null || echo "No logs for opendatahub-operator/opendatahub-operator"
 
 if [ "$success" -ne 1 ]; then
     exit 1


### PR DESCRIPTION
Removes the collections of an odh-operator pod log that never exists in an ODH deployment

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>