### PR TITLE
Move the JH DeploymentConfig imageChange trigger to an overlay

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -45,7 +45,7 @@ A ConfigMap containing comma separated lists of groups which would be used as Ad
 
 ### Overlays
 
-JupyterHub component comes with 2 overlays.
+JupyterHub component comes with 3 overlays.
 
 #### build
 
@@ -54,6 +54,10 @@ Contains build manifests for JupyterHub images.
 #### storage-class
 
 Customizes JupyterHub to use a specific `StorageClass` for PVCs, see `storage_class` parameter.
+
+#### trigger-imagechange
+
+Adds an `imageChange` trigger to the JupyterHub DeploymentConfig to enable automatic redeployment of the JupterHub server when the `jupyterhub-img` `ImagestreamTag` is updated
 
 ## Notebook Images
 

--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -118,13 +118,4 @@ spec:
         name: config
   triggers:
   - type: ConfigChange
-  - type: ImageChange
-    imageChangeParams: 
-      automatic: true
-      containerNames:
-        - wait-for-database
-        - jupyterhub
-      from:
-        kind: ImageStreamTag
-        name: jupyterhub-img:latest
-        
+

--- a/jupyterhub/jupyterhub/overlays/trigger-imagechange/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/overlays/trigger-imagechange/jupyterhub-dc.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/triggers/-
+  value:
+    type: ImageChange
+    imageChangeParams:
+      automatic: true
+      containerNames:
+        - wait-for-database
+        - jupyterhub
+      from:
+        kind: ImageStreamTag
+        name: jupyterhub-img:latest

--- a/jupyterhub/jupyterhub/overlays/trigger-imagechange/kustomization.yaml
+++ b/jupyterhub/jupyterhub/overlays/trigger-imagechange/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesJson6902:
+- target:
+    group: apps.openshift.io
+    kind: DeploymentConfig
+    version: v1
+    name: jupyterhub
+  path: jupyterhub-dc.yaml


### PR DESCRIPTION
Move the enablement of the JupyterHub DeploymentConfig imageChange trigger for JH to an optional overlay.

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>

You can test with the `kfdef` below
1. The JH deploymentconfig should have the `imageChange` trigger added when the `trigger-imagechange` overlay is enabled
2. Remove the `trigger-imagechange` overlay and only the `ConfigChange` trigger should exist in jupyterhub deployment config

```bash
# Check the current value of the jupyterhub deploymentconfig triggers
oc get dc jupyterhub -o json | jq '.spec.triggers'
```

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
  namespace: opendatahub
spec:
  applications:
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        overlays:
          - trigger-imagechange
        parameters:
          - name: s3_endpoint_url
            value: "s3.odh.com"
        repoRef:
          name: manifests-lavlas
          path: jupyterhub/jupyterhub
      name: jupyterhub
    - kustomizeConfig:
        overlays:
          - additional
        repoRef:
          name: manifests
          path: jupyterhub/notebook-images
      name: notebook-images
  repos:
    - name: manifests
      uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
    - name: manifests-lavlas
      uri: https://github.com/lavlas/odh-manifests/tarball/fix/jh-imagechange-trigger
```


