### PR TITLE
Update s2i-lab-elyra notebook image to v0.0.7

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.6
-    name: "v0.0.6"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.7
+    name: "v0.0.7"
     referencePolicy:
       type: Source


### PR DESCRIPTION
This change will update the version of Elyra in the container
to v2.2.1

- [x] Dependent on https://github.com/opendatahub-io/s2i-lab-elyra/pull/26 building v0.0.7 of the [s2i-lab-elyra](https://quay.io/repository/thoth-station/s2i-lab-elyra?tab=tags) image prior to merging