### PR TITLE
Add generic data science notebook to JH deployment

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -1,0 +1,22 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/thoth-station/s2i-generic-data-science-notebook"
+    opendatahub.io/notebook-image-name: "Generic Data Scient Notebook Image"
+    opendatahub.io/notebook-image-desc: "Jupyter notebook image with a set of data science libraries that advanced AI/ML notebooks will use as a base image to provide a standard for libraries avialable in all notebooks"
+  name: s2i-generic-data-science-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      openshift.io/imported-from: quay.io/thoth-station/s2i-generic-data-science-notebook
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.2
+    name: "v0.0.2"
+    referencePolicy:
+      type: Source

--- a/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - ../../base
 resources:
 - minimal-notebook-imagestream.yaml
+- generic-data-science-notebook-imagestream.yaml
 - scipy-notebook-imagestream.yaml
 - tensorflow-notebook-imagestream.yaml
 - spark-scipy-notebook-imagestream.yaml

--- a/jupyterhub/notebook-images/overlays/build/generic-data-science-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/generic-data-science-notebook-buildconfig.yaml
@@ -1,0 +1,34 @@
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  labels:
+    build: s2i-generic-data-science-notebook
+  name: s2i-generic-data-science-notebook
+spec:
+  output:
+    to:
+      kind: ImageStreamTag
+      name: s2i-generic-data-science-notebook:local-build
+  source:
+    git:
+      uri: https://github.com/thoth-station/s2i-generic-data-science-notebook
+    type: Git
+  strategy:
+    sourceStrategy:
+      from:
+        kind: ImageStreamTag
+        name: s2i-minimal-notebook:local-build
+      env:
+      - name: "ENABLE_PIPENV"
+        value: "1"
+      - name: "THOTH_DRY_RUN"
+        value: "1"
+      - name: "THOTH_ADVISE"
+        value: "0"
+      - name: "THOTH_PROVENANCE_CHECK"
+        value: "0"
+      - name: "THOTH_ERROR_FALLBACK"
+        value: "1"
+    type: Source
+  triggers:
+  - type: ConfigChange

--- a/jupyterhub/notebook-images/overlays/build/kustomization.yaml
+++ b/jupyterhub/notebook-images/overlays/build/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - ../../base
 resources:
 - minimal-notebook-buildconfig.yaml
+- generic-data-science-notebook-buildconfig.yaml
 - scipy-notebook-buildconfig.yaml
 - tensorflow-notebook-buildconfig.yaml
 - spark-minimal-notebook-buildconfig.yaml

--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -11,8 +11,8 @@ JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
 OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
 JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
 
-JUPYTER_IMAGES=("s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3" s2i-minimal-notebook:v0.0.7 s2i-scipy-notebook:v0.0.2 s2i-tensorflow-notebook:v0.0.2)
-JUPYTER_NOTEBOOK_FILES=(spark.ipynb basic.ipynb basic.ipynb tensorflow.ipynb)
+JUPYTER_IMAGES=("s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3" s2i-minimal-notebook:v0.0.7 s2i-scipy-notebook:v0.0.2 s2i-tensorflow-notebook:v0.0.2 s2i-generic-data-science-notebook:v0.0.2)
+JUPYTER_NOTEBOOK_FILES=(spark.ipynb basic.ipynb basic.ipynb tensorflow.ipynb basic.ipynb)
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"
 


### PR DESCRIPTION
Adds the generic data science notebook to the list of `additional` jupyter notebooks