### PR TITLE
Update JH image to fix GPU setting and CI issue

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-img-imagestream.yaml
@@ -11,7 +11,7 @@ spec:
       openshift.io/imported-from: quay.io/odh-jupyterhub/jupyterhub-img
     from:
       kind: DockerImage
-      name: quay.io/odh-jupyterhub/jupyterhub-img:v0.2.5
+      name: quay.io/odh-jupyterhub/jupyterhub-img:v0.2.7
     name: latest
     referencePolicy:
       type: Source


### PR DESCRIPTION
This PR updates JH image to latest version which:

* Fixes an issue where GPU is not attached if a non-default size is selected
* Fixes the CI bug where default image was chosen by mistake