### PR TITLE
update of data science notebook having s3 browser extension

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -18,7 +18,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-generic-data-science-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.2
-    name: "v0.0.2"
+      name: quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.3
+    name: "v0.0.3"
     referencePolicy:
       type: Source

--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -11,7 +11,7 @@ JH_LOGIN_PASS=${OPENSHIFT_PASS:-"admin"} #Password used to login to JH
 OPENSHIFT_LOGIN_PROVIDER=${OPENSHIFT_LOGIN_PROVIDER:-"htpasswd-provider"} #OpenShift OAuth provider used for login
 JH_AS_ADMIN=${JH_AS_ADMIN:-"true"} #Expect the user to be Admin in JupyterHub
 
-JUPYTER_IMAGES=("s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3" s2i-minimal-notebook:v0.0.7 s2i-scipy-notebook:v0.0.2 s2i-tensorflow-notebook:v0.0.2 s2i-generic-data-science-notebook:v0.0.2)
+JUPYTER_IMAGES=("s2i-spark-minimal-notebook:py36-spark2.4.5-hadoop2.7.3" s2i-minimal-notebook:v0.0.7 s2i-scipy-notebook:v0.0.2 s2i-tensorflow-notebook:v0.0.2 s2i-generic-data-science-notebook:v0.0.3)
 JUPYTER_NOTEBOOK_FILES=(spark.ipynb basic.ipynb basic.ipynb tensorflow.ipynb basic.ipynb)
 
 os::test::junit::declare_suite_start "$MY_SCRIPT"


### PR DESCRIPTION
update of data science notebook having s3 browser extension
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

This would include the https://github.com/IBM/jupyterlab-s3-browser extension in the generic data science notebook.
