### PR TITLE
Seldon update

### DIFF
--- a/odhseldon/cluster/base/subscription.yaml
+++ b/odhseldon/cluster/base/subscription.yaml
@@ -4,9 +4,9 @@ metadata:
   name: seldon-operator-certified
   namespace: opendatahub
 spec:
-  channel: alpha
+  channel: stable
   installPlanApproval: Automatic
   name: seldon-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: seldon-operator.v1.2.0
+  startingCSV: seldon-operator.v1.7.0


### PR DESCRIPTION
Seldon has switched from the alpha channel to stable and new releases are available under the new stable channel.

This update switches the subscription channel and updates to the latest version of Seldon for the startingCSV.