### PR TITLE
Split the JSP configmap into profiles and sizes

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -54,29 +54,3 @@ data:
               spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
             return:
               SPARK_CLUSTER: 'metadata.name'
-
-      sizes:
-      - name: Small
-        resources:
-          requests:
-            memory: 1Gi
-            cpu: 1
-          limits:
-            memory: 2Gi
-            cpu: 2
-      - name: Medium
-        resources:
-          requests:
-            memory: 2Gi
-            cpu: 2
-          limits:
-            memory: 4Gi
-            cpu: 4
-      - name: Large
-        resources:
-          requests:
-            memory: 4Gi
-            cpu: 4
-          limits:
-            memory: 8Gi
-            cpu: 8

--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-sizes-configmap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-jupyterhub-sizes
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      sizes:
+      - name: Small
+        resources:
+          requests:
+            memory: 1Gi
+            cpu: 1
+          limits:
+            memory: 2Gi
+            cpu: 2
+      - name: Medium
+        resources:
+          requests:
+            memory: 2Gi
+            cpu: 2
+          limits:
+            memory: 4Gi
+            cpu: 4
+      - name: Large
+        resources:
+          requests:
+            memory: 4Gi
+            cpu: 4
+          limits:
+            memory: 8Gi
+            cpu: 8

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 - jupyterhub-rolebinding.yaml
 - jupyterhub-route.yaml
 - jupyterhub-singleuser-profiles-configmap.yaml
+- jupyterhub-singleuser-profiles-sizes-configmap.yaml
 - jupyterhub-spark-operator-configmap.yaml
 - jupyterhub-groups-configmap.yaml
 


### PR DESCRIPTION
Since Sizes are list which we can only add to at the moment, this change will make it easier to overwrite existing sizes completely by and overlay/patch (i.e. by replacing whole resource)