### PR TITLE
Update OpenShift Pipelines starting version to v1.3.1

### DIFF
--- a/openshift-pipelines/cluster/base/subscription.yaml
+++ b/openshift-pipelines/cluster/base/subscription.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: stable
   installPlanApproval: Automatic
-  startingCSV: redhat-openshift-pipelines-operator.v1.2.3
+  startingCSV: redhat-openshift-pipelines.v1.3.1
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Update the starting version for the OpenShift Pipelines operator subscription

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>