### PR TITLE
Update Kafka Operator Subscription to v0.22.x

### DIFF
--- a/kafka/cluster/base/subscription.yaml
+++ b/kafka/cluster/base/subscription.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -5,6 +6,6 @@ metadata:
   namespace: openshift-operators
 spec:
   name: strimzi-kafka-operator
-  channel: "strimzi-0.19.x"
+  channel: "strimzi-0.22.x"
   source: community-operators
   sourceNamespace: openshift-marketplace

--- a/kafka/kafka/base/kafka-cluster.yaml
+++ b/kafka/kafka/base/kafka-cluster.yaml
@@ -1,152 +1,49 @@
 ---
-apiVersion: kafka.strimzi.io/v1alpha1
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: odh-message-bus
 spec:
   kafka:
-    version: "2.4.0"
+    version: 2.7.0
     replicas: 3
     listeners:
-      plain: {}
-      tls: {}
-      external:
+      - name: plain
+        port: 9092
+        type: internal
+        tls: false
+      - name: tls
+        port: 9093
+        type: internal
+        tls: true
+      - name: external
+        port: 9094
         type: route
+        tls: true
     config:
       offsets.topic.replication.factor: 3
       transaction.state.log.replication.factor: 3
       transaction.state.log.min.isr: 3
-      log.message.format.version: "2.4"
+      log.message.format.version: '2.7'
+      inter.broker.protocol.version: '2.7'
     storage:
       type: ephemeral
-    metrics:
-      # Inspired by config from Kafka 2.0.0 example rules:
-      # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-2_0_0.yml
-      lowercaseOutputName: true
-      rules:
-      # Special cases and very specific rules
-      - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
-        name: kafka_server_$1_$2
-        type: GAUGE
-        labels:
-          clientId: "$3"
-          topic: "$4"
-          partition: "$5"
-      - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
-        name: kafka_server_$1_$2
-        type: GAUGE
-        labels:
-          clientId: "$3"
-          broker: "$4:$5"
-      # Some percent metrics use MeanRate attribute
-      # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-      # Generic gauges for percents
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3_percent
-        type: GAUGE
-        labels:
-          "$4": "$5"
-      # Generic per-second counters with 0-2 key/value pairs
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
-        name: kafka_$1_$2_$3_total
-        type: COUNTER
-      # Generic gauges with 0-2 key/value pairs
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
-        name: kafka_$1_$2_$3
-        type: GAUGE
-      # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
-      # Note that these are missing the '_sum' metric!
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          "$6": "$7"
-          quantile: "0.$8"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-        labels:
-          "$4": "$5"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          "$4": "$5"
-          quantile: "0.$6"
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
-        name: kafka_$1_$2_$3_count
-        type: COUNTER
-      - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
-        name: kafka_$1_$2_$3
-        type: GAUGE
-        labels:
-          quantile: "0.$4"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics-config
+          key: kafka-prometheus-metrics
   zookeeper:
     replicas: 3
     storage:
       type: ephemeral
-    metrics:
-      # Inspired by Zookeeper rules
-      # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/zookeeper.yaml
-      lowercaseOutputName: true
-      rules:
-      # replicated Zookeeper
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
-        name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
-        name: "zookeeper_$3"
-        labels:
-          replicaId: "$2"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
-        name: "zookeeper_$4"
-        labels:
-          replicaId: "$2"
-          memberType: "$3"
-      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
-        name: "zookeeper_$4_$5"
-        labels:
-          replicaId: "$2"
-          memberType: "$3"
-      # standalone Zookeeper
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
-        name: "zookeeper_$2"
-      - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=(InMemoryDataTree)><>(\\w+)"
-        name: "zookeeper_$2_$3"
+    metricsConfig:
+      type: jmxPrometheusExporter
+      valueFrom:
+        configMapKeyRef:
+          name: kafka-metrics-config
+          key: zookeeper-prometheus-metrics
   entityOperator:
     topicOperator: {}
     userOperator: {}

--- a/kafka/kafka/base/kafka-metrics-config.yaml
+++ b/kafka/kafka/base/kafka-metrics-config.yaml
@@ -1,0 +1,130 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kafka-metrics-config
+data:
+  kafka-prometheus-metrics: |
+    # Inspired by config from Kafka 2.0.0 example rules:
+    # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/kafka-2_0_0.yml
+    lowercaseOutputName: true
+    rules:
+    # Special cases and very specific rules
+    - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+        clientId: "$3"
+        topic: "$4"
+        partition: "$5"
+    - pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+      name: kafka_server_$1_$2
+      type: GAUGE
+      labels:
+        clientId: "$3"
+        broker: "$4:$5"
+    # Some percent metrics use MeanRate attribute
+    # Ex) kafka.server<type=(KafkaRequestHandlerPool), name=(RequestHandlerAvgIdlePercent)><>MeanRate
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+    # Generic gauges for percents
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>Value
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*, (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3_percent
+      type: GAUGE
+      labels:
+        "$4": "$5"
+    # Generic per-second counters with 0-2 key/value pairs
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+    # Generic gauges with 0-2 key/value pairs
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+      name: kafka_$1_$2_$3
+      type: GAUGE
+    # Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+    # Note that these are missing the '_sum' metric!
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+        quantile: "0.$8"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        "$4": "$5"
+        quantile: "0.$6"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+      name: kafka_$1_$2_$3_count
+      type: COUNTER
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+      name: kafka_$1_$2_$3
+      type: GAUGE
+      labels:
+        quantile: "0.$4"
+  zookeeper-prometheus-metrics: |
+    # Inspired by Zookeeper rules
+    # https://github.com/prometheus/jmx_exporter/blob/master/example_configs/zookeeper.yaml
+    lowercaseOutputName: true
+    rules:
+    # replicated Zookeeper
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
+      name: "zookeeper_$2"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
+      name: "zookeeper_$3"
+      labels:
+        replicaId: "$2"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
+      name: "zookeeper_$4"
+      labels:
+        replicaId: "$2"
+        memberType: "$3"
+    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
+      name: "zookeeper_$4_$5"
+      labels:
+        replicaId: "$2"
+        memberType: "$3"
+    # standalone Zookeeper
+    - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+)><>(\\w+)"
+      name: "zookeeper_$2"
+    - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=(InMemoryDataTree)><>(\\w+)"
+      name: "zookeeper_$2_$3"

--- a/kafka/kafka/base/kustomization.yaml
+++ b/kafka/kafka/base/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - kafka-cluster.yaml
-
+- kafka-metrics-config.yaml


### PR DESCRIPTION
Update Kafka CR to the newer structure
* This updates `spec.kafka.listeners` to the newer structure ([docs](https://strimzi.io/docs/operators/latest/using.html#configuration-listener-network-policy-reference))
* This updates `spec.kafka.metrics` to `spec.kafka.metricsConfig` as the former has been deprecated ([docs](https://strimzi.io/docs/operators/latest/using.html#type-KafkaClusterSpec-schema-reference))
* This updates `spec.zookeeper.metrics` to `spec.zookeeper.metricsConfig` as the former has been deprecated ([docs](https://strimzi.io/docs/operators/latest/using.html#type-ZookeeperClusterSpec-schema-reference))

Closes https://github.com/opendatahub-io/odh-manifests/issues/404