### PR TITLE
Add latest tag for s2i-lab-elyra JH image

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -20,3 +20,13 @@ spec:
     name: "v0.0.7"
     referencePolicy:
       type: Source
+  - annotations:
+      openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
+    from:
+      kind: DockerImage
+      name: quay.io/thoth-station/s2i-lab-elyra:latest
+    name: "latest"
+    importPolicy:
+      scheduled: true
+    referencePolicy:
+      type: Source


### PR DESCRIPTION
This will add a `latest` tag for the `s2i-lab-elyra` image which will update regularly.

cc @ptitzler