### PR TITLE
Update JH dashboard jsons

### DIFF
--- a/grafana/grafana/base/jupyterhub-dashboards/jupyterhub-sli-slo.json
+++ b/grafana/grafana/base/jupyterhub-dashboards/jupyterhub-sli-slo.json
@@ -87,7 +87,7 @@
       "type": "text"
     },
     {
-      "datasource": "opendatahub",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -168,7 +168,7 @@
       "type": "stat"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -358,7 +358,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {},
@@ -704,7 +704,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -973,7 +973,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -1362,7 +1362,7 @@
       "type": "text"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {

--- a/grafana/grafana/base/jupyterhub-dashboards/jupyterhub-usage.json
+++ b/grafana/grafana/base/jupyterhub-dashboards/jupyterhub-usage.json
@@ -84,7 +84,7 @@
       "type": "text"
     },
     {
-      "datasource": null,
+      "datasource": "$datasource",
       "description": "",
       "fieldConfig": {
         "defaults": {
@@ -148,7 +148,7 @@
       "type": "bargauge"
     },
     {
-      "datasource": "opendatahub",
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {
@@ -282,7 +282,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -407,7 +407,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -563,7 +563,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {}
@@ -684,7 +684,7 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": null,
+      "datasource": "$datasource",
       "fieldConfig": {
         "defaults": {
           "custom": {}


### PR DESCRIPTION
Minor change to the JH dashboard template variables in the panel queries. Earlier, the queries were being run on a pre-selected datasource (i.e. `opendatahub`), changing this to run the queries on the selected datasource in the `$datasource` filter instead. This will make the dashboards more generic in nature.

cc @anishasthana @LaVLaS