### PR TITLE
Update elyra notebook image to v0.0.8

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -16,7 +16,7 @@ spec:
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.7
-    name: "v0.0.7"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.8
+    name: "v0.0.8"
     referencePolicy:
       type: Source


### PR DESCRIPTION
Bumps Elyra to version 2.2.4
Change log:
https://github.com/elyra-ai/elyra/blob/master/docs/source/getting_started/changelog.md