### PR TITLE
Add builds and buildconfigs read permissions to odh-dashboard role

### DIFF
--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -19,3 +19,12 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - build.openshift.io
+    verbs:
+      - get
+      - list
+      - watch
+    resources:
+      - builds
+      - buildconfigs


### PR DESCRIPTION
This change is required because the dashboard is watching build statuses to notify the user of builds in progress, failure, and completion.