### PR TITLE
Update JupyterHub base image source to v3.5.3

### DIFF
--- a/jupyterhub/jupyterhub/overlays/build/jupyterhub-buildconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/build/jupyterhub-buildconfig.yaml
@@ -12,7 +12,7 @@ spec:
       name: jupyterhub:latest
   source:
     git:
-      ref: v3.5.1
+      ref: v3.5.3
       uri: https://github.com/opendatahub-io/jupyterhub-quickstart.git
     type: Git
   strategy:


### PR DESCRIPTION
This can prevent some problems that may appear when using the build config manually.