### PR TITLE
Fix missing names in additional image streams

### DIFF
--- a/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/base/spark-notebook-imagestream.yaml
@@ -3,6 +3,8 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name: "Minimal Python with Apache Spark"
   name: s2i-spark-minimal-notebook
 spec:
   lookupPolicy:

--- a/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/spark-scipy-notebook-imagestream.yaml
@@ -3,6 +3,8 @@ kind: ImageStream
 metadata:
   labels:
     opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-name: "Minimal Python with Apache Spark and SciPy"
   name: s2i-spark-scipy-notebook
 spec:
   lookupPolicy:


### PR DESCRIPTION
Related to: https://github.com/operate-first/support/issues/276
Resolves: https://issues.redhat.com/browse/ODH-402

When applying `v1.1.0` we've noticed some ImageStreams from the `additional` overlay are missing names from the Spawner UI.

Feel free to suggest better names and/or descriptions.

![](https://user-images.githubusercontent.com/22333506/122776404-13ccd980-d279-11eb-93ba-5e7e5f56cd41.png)