### PR TITLE
Add build and build config get permissions for jupyterhub

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
@@ -109,3 +109,12 @@ rules:
   - delete
   - deletecollection
   - watch
+- apiGroups:
+  - build.openshift.io
+  resources:
+    - builds
+    - buildconfigs
+  verbs:
+    - get
+    - list
+    - watch


### PR DESCRIPTION
Spawner needs to fetch builds and buildconfigs to determine build status of notebooks.

/cc @mroman-redhat @vpavlin 