### PR TITLE
upgrade the base images with ubi8 updates

### DIFF
--- a/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/elyra-notebook-imagestream.yaml
@@ -13,10 +13,12 @@ spec:
     local: true
   tags:
   - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.6"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"elyra","version":"2.2.4"}]'
       openshift.io/imported-from: quay.io/thoth-station/s2i-lab-elyra
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.8
-    name: "v0.0.8"
+      name: quay.io/thoth-station/s2i-lab-elyra:v0.0.9
+    name: "v0.0.9"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/generic-data-science-notebook-imagestream.yaml
@@ -14,11 +14,11 @@ spec:
   tags:
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.6"}]'
-      opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.17.11"},{"name":"Kafka-Python","version":"2.0.2"},{"name":"Matplotlib","version":"3.1.3"},{"name":"Numpy","version":"1.20.3"},{"name":"Pandas","version":"1.2.4"},{"name":"Scipy","version":"1.6.3"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"Boto3","version":"1.17.11"},{"name":"Kafka-Python","version":"2.0.2"},{"name":"Matplotlib","version":"3.4.2"},{"name":"Numpy","version":"1.21.0"},{"name":"Pandas","version":"1.2.5"},{"name":"Scipy","version":"1.7.0"}]'
       openshift.io/imported-from: quay.io/thoth-station/s2i-generic-data-science-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.4
-    name: "v0.0.4"
+      name: quay.io/thoth-station/s2i-generic-data-science-notebook:v0.0.5
+    name: "v0.0.5"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
+++ b/jupyterhub/notebook-images/overlays/additional/minimal-notebook-imagestream.yaml
@@ -13,22 +13,22 @@ spec:
     local: true
   tags:
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.3"}]'
-      opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.0.14"}, {"name": "Notebook","version": "6.3.0"}]'
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8.6"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.0.16"}, {"name": "Notebook","version": "6.4.0"}]'
       openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-py38-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.14
-    name: "v0.0.14"
+      name: quay.io/thoth-station/s2i-minimal-py38-notebook:v0.0.15
+    name: "v0.0.15"
     referencePolicy:
       type: Source
   - annotations:
       opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.6.8"}]'
-      opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "2.2.4"}, {"name": "Notebook","version": "6.2.0"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version": "3.0.14"}, {"name": "Notebook","version": "6.3.0"}]'
       openshift.io/imported-from: quay.io/thoth-station/s2i-minimal-notebook
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.7
-    name: "v0.0.7"
+      name: quay.io/thoth-station/s2i-minimal-notebook:v0.0.15
+    name: "v0.0.15"
     referencePolicy:
       type: Source

--- a/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
+++ b/jupyterhub/notebook-images/overlays/build/elyra-notebook-buildconfig.yaml
@@ -8,11 +8,11 @@ spec:
   output:
     to:
       kind: ImageStreamTag
-      name: s2i-lab-elyra:v0.0.7
+      name: s2i-lab-elyra:v0.0.9
   source:
     git:
       uri: https://github.com/opendatahub-io/s2i-lab-elyra
-      ref: v0.0.7
+      ref: v0.0.9
     type: Git
   strategy:
     sourceStrategy:


### PR DESCRIPTION
upgrade the base images with ubi8 updates
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

These image have python upgrade and vulnerability fixes.
ubi8-python38 base image upgrade form 1-47 tag to 1-60 tag.

Related-to: https://github.com/AICoE/meteor/issues/29