### PR TITLE
Added sidecar leader election on JH

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -8,7 +8,7 @@ metadata:
     app: jupyterhub
   name: jupyterhub
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     app: jupyterhub
     deploymentconfig: jupyterhub
@@ -103,6 +103,17 @@ spec:
         volumeMounts:
         - mountPath: /opt/app-root/configs
           name: config
+        readinessProbe:
+            tcpSocket:
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 10
+      - name: jupyterhub-ha-sidecar
+        image: gcr.io/google_containers/leader-elector:0.5
+        args:
+        - --election=jupyterhub-ha-election
+        - --election-namespace=$(namespace)
+        - --http=0.0.0.0:4040
       initContainers:
       - command:
         - wait-for-database

--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -91,7 +91,7 @@ spec:
             configMapKeyRef:
               name: jupyterhub-cfg
               key: notebook_destination
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.1
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.2-test
         imagePullPolicy: "Always"
         name: jupyterhub
         ports:
@@ -125,7 +125,7 @@ spec:
               key: POSTGRESQL_PASSWORD
         - name: JUPYTERHUB_DATABASE_HOST
           value: jupyterhub-db
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.1
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.2-test
         imagePullPolicy: "Always"
         name: wait-for-database
         resources:

--- a/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-role.yaml
@@ -31,6 +31,7 @@ rules:
   - persistentvolumeclaims
   - pods
   - services
+  - endpoints
   verbs:
   - create
   - delete
@@ -46,6 +47,7 @@ rules:
   - persistentvolumeclaims
   - pods
   - services
+  - endpoints
   verbs:
   - get
   - list

--- a/jupyterhub/jupyterhub/base/params.yaml
+++ b/jupyterhub/jupyterhub/base/params.yaml
@@ -8,9 +8,9 @@ varReference:
   kind: ConfigMap
 - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class
   kind: PersistentVolumeClaim
-- path: spec/template/spec/containers/env/valueFrom/configMapKeyRef/name
+- path: spec/template/spec/containers[]/env/valueFrom/configMapKeyRef/name
   kind: DeploymentConfig
-- path: spec/template/spec/containers/env/valueFrom/secretKeyRef/name
+- path: spec/template/spec/containers[]/env/valueFrom/secretKeyRef/name
   kind: DeploymentConfig
 - path: spec/template/spec/initContainers/env/valueFrom/secretKeyRef/name
   kind: DeploymentConfig
@@ -18,3 +18,5 @@ varReference:
   kind: ConfigMap
 - path: subjects/name
   kind: RoleBinding
+- path: spec/template/spec/containers[]/args
+  kind: DeploymentConfig

--- a/tests/basictests/jupyterhub.sh
+++ b/tests/basictests/jupyterhub.sh
@@ -21,7 +21,7 @@ function test_jupyterhub() {
     os::cmd::try_until_text "oc get deploymentconfig jupyterhub-db" "jupyterhub-db" $odhdefaulttimeout $odhdefaultinterval
     os::cmd::try_until_text "oc get pods -l deploymentconfig=jupyterhub --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "jupyterhub" $odhdefaulttimeout $odhdefaultinterval
     runningpods=($(oc get pods -l deploymentconfig=jupyterhub --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
-    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"
+    os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "3"
     os::cmd::try_until_text "oc get pods -l deploymentconfig=jupyterhub-db --field-selector='status.phase=Running' -o jsonpath='{$.items[*].metadata.name}'" "jupyterhub-db" $odhdefaulttimeout $odhdefaultinterval
     runningpods=($(oc get pods -l deploymentconfig=jupyterhub-db --field-selector="status.phase=Running" -o jsonpath="{$.items[*].metadata.name}"))
     os::cmd::expect_success_and_text "echo ${#runningpods[@]}" "1"


### PR DESCRIPTION
---

name: Pull Request
about: Contribute a new pull request
title: 'Add sidecar leader election on JH'

---

**Changes proposed in this pull request**
- Added a sidecar container for a [leader election strategy](https://kubernetes.io/blog/2016/01/simple-leader-election-with-kubernetes/)
- Updated Jupyterhub Pods from 1 to 3

**Test instructions (required)**
To test this deployment, follow these steps:

1. On your OC cluster, install the ODH Operator
2. Run a new instance, replacing with the following repository the KfDef file: 

```
- name: manifests
      uri: 'https://github.com/lucferbux/odh-manifests/tarball/feature/leader-election'
```

**Closing issues**
* https://issues.redhat.com/browse/ODH-422

For further info you can check this [test log](https://docs.google.com/document/d/1mpDir4GjhSrs3awMOsNKmD3tAME2uks9mW0Gh1q4CKc/edit?usp=sharing)
