### PR TITLE
Add required permissions for adding notebooks in custom namespaces

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
@@ -6,6 +6,17 @@ metadata:
   name: jupyterhub-cluster
 rules:
   - verbs:
+      - create
+      - delete
+      - deletecollection
+      - patch
+      - update
+    apiGroups:
+      - ''
+    resources:
+      - persistentvolumeclaims
+      - pods
+  - verbs:
       - get
       - watch
       - list
@@ -22,3 +33,5 @@ rules:
       - ''
     resources:
       - nodes
+      - pods
+      - events

--- a/jupyterhub/jupyterhub/base/jupyterhub-cluster-rolebinding.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-cluster-rolebinding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jupyterhub-cluster
+  name: jupyterhub-cluster-$(namespace)
 subjects:
   - kind: ServiceAccount
     name: jupyterhub-hub

--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -86,7 +86,7 @@ spec:
             secretKeyRef:
               name: $(jupyterhub_secret)
               key: CONFIGPROXY_AUTH_TOKEN
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.0
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.1
         imagePullPolicy: "Always"
         name: jupyterhub
         ports:
@@ -109,7 +109,7 @@ spec:
               key: POSTGRESQL_PASSWORD
         - name: JUPYTERHUB_DATABASE_HOST
           value: jupyterhub-db
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.0
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.1
         imagePullPolicy: "Always"
         name: wait-for-database
         resources:

--- a/jupyterhub/jupyterhub/base/params.yaml
+++ b/jupyterhub/jupyterhub/base/params.yaml
@@ -4,6 +4,9 @@ varReference:
 - path: subjects/namespace
   kind: ClusterRoleBinding
   apiGroup: authorization.openshift.io
+- path: metadata/name
+  kind: ClusterRoleBinding
+  apiGroup: authorization.openshift.io
 - path: data
   kind: ConfigMap
 - path: metadata/annotations/volume.beta.kubernetes.io\/storage-class


### PR DESCRIPTION
This PR should add all the neccessary permissions to allow JupyterHub to spawn a notebook on a different namespace than the jupyterhub pod itself. Related to: https://github.com/opendatahub-io/jupyterhub-odh/pull/101