### PR TITLE
Bugfix JupyterHub Leader Election

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -141,7 +141,7 @@ spec:
             secretKeyRef:
               name: $(traefik_credentials_secret)
               key: TRAEFIK_API_PASSWORD
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.4
         imagePullPolicy: "Always"
         name: jupyterhub
         ports:
@@ -162,6 +162,14 @@ spec:
               port: 8081
             initialDelaySeconds: 15
             periodSeconds: 10
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - /opt/app-root/src/readinessProbe.sh
+          initialDelaySeconds: 40
+          periodSeconds: 10
       - name: jupyterhub-ha-sidecar
         image: 'registry.redhat.io/openshift4/ose-leader-elector-rhel8:v4.7'
         args:
@@ -180,6 +188,41 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.name
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - >
+              function is_leader_election_ready()() {
+                  [ $(curl -s -o /dev/null -w ''%{http_code}'' localhost:4040) == "200" ]
+              }
+
+              function get_leader() {
+                  echo "$(curl http://localhost:4040 2> /dev/null | python3 -c "import sys, json; print(json.load(sys.stdin)['name'])")"
+              }
+
+              function is_empty_string() {
+                  # When the sidecar container is not working the name of the leader is an empty string
+                  [ "$(get_leader)" == "" ]
+              };
+
+              if ! is_leader_election_ready(); then
+                  # Sidecar container is not ready yet
+                  exit 0
+              fi
+
+              if is_empty_string; then
+                  # Sidecar container is returning an empty string, there must be a problem
+                  # Sleep for a while to let the rest of the container to restart too
+                  sleep 9
+                  exit 1
+              else
+                  # Pod is working, we can exit with success
+                  exit 0
+              fi
+          initialDelaySeconds: 40
+          periodSeconds: 10
       initContainers:
       - command:
         - wait-for-database
@@ -191,7 +234,7 @@ spec:
               key: POSTGRESQL_PASSWORD
         - name: JUPYTERHUB_DATABASE_HOST
           value: jupyterhub-db
-        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3
+        image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.4
         imagePullPolicy: "Always"
         name: wait-for-database
         resources:


### PR DESCRIPTION
---
Title: Bugfix JupyterHub Leader Election
---

### Changes proposed in this pull request
As we have implemented High Availability on Jupyterhub, we shifted from 1 to 3 containers with the Leader Election strategy.

With this implementation, we could bump into inconsistencies given that one Pod could be thinking he's still the leader elected, but others could have replaced it due to network problems.

Implement a check to detect if a pod running is still the leader elected, and if not, delete it.

#### Diagram

<img width="661" alt="leader-election" src="https://user-images.githubusercontent.com/16117276/130628420-8339647f-3022-4051-8fbb-d4bf01c191aa.png">

### Issues

* https://issues.redhat.com/browse/ODH-453

### Test instructions

* Check the instructions inside the [testing documentation](https://docs.google.com/document/d/1Ga0khZqr-jGpi5ExPJ0Cz8RawI0INc0UGI6Q2O3fTJc/edit#) about the ODH Manifest deployment
* Use this branch as the base image
* You can use olminstall to deploy to the dev cluster the changes
[TODO: How to check that changes are working]



