### PR TITLE
Removed sidecar liveness probe

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -186,41 +186,6 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.name
-        livenessProbe:
-          exec:
-            command:
-            - /bin/sh
-            - -c
-            - >
-              function is_leader_election_ready()() {
-                  [ $(curl -s -o /dev/null -w ''%{http_code}'' localhost:4040) == "200" ]
-              }
-
-              function get_leader() {
-                  echo "$(curl http://localhost:4040 2> /dev/null | python3 -c "import sys, json; print(json.load(sys.stdin)['name'])")"
-              }
-
-              function is_empty_string() {
-                  # When the sidecar container is not working the name of the leader is an empty string
-                  [ "$(get_leader)" == "" ]
-              };
-
-              if ! is_leader_election_ready(); then
-                  # Sidecar container is not ready yet
-                  exit 0
-              fi
-
-              if is_empty_string; then
-                  # Sidecar container is returning an empty string, there must be a problem
-                  # Sleep for a while to let the rest of the container to restart too
-                  sleep 9
-                  exit 1
-              else
-                  # Pod is working, we can exit with success
-                  exit 0
-              fi
-          initialDelaySeconds: 40
-          periodSeconds: 10
       initContainers:
       - command:
         - wait-for-database


### PR DESCRIPTION
---
Title: Removed sidecar liveness probe
---

**Changes proposed in this pull request**
 - Delete the liveness probe inside the sidecar container, as it's not covering anything relevant (this probe was created for he old image)

**Test instructions (required)**
 - Deploy the new version in the cluster

**Next steps**
 - It should be nice to add a new livenessprobe to ensure fencing in the liveness probe, but this should be implemented alongside some changes in the leader-election golang script.
