### PR TITLE
Add CRDs for applications, documentations resources, and quick starts

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-app.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-app.yaml
@@ -1,0 +1,190 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhApplication
+metadata:
+  name: jupyterhub
+  annotations:
+    opendatahub.io/categories: 'Jupyter notebook'
+spec:
+  displayName: JupyterHub
+  provider: Jupyter
+  description: |-
+    A multi-user version of the notebook designed for companies, classrooms and research labs.
+  kfdefApplications: ['jupyterhub', 'notebook-images']
+  route: jupyterhub
+  img: |-
+    <svg version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+    	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="-336 437 351 151"
+    	 enable-background="new -336 437 351 151" xml:space="preserve">
+      <title>Group Copy 2</title>
+      <desc>Created with Sketch.</desc>
+      <g id="Page-1" sketch:type="MSPage">
+          <g id="Home---Desktop-Copy-2" transform="translate(-144.000000, -2506.000000)" sketch:type="MSArtboardGroup">
+              <g id="Group" transform="translate(97.000000, 2493.000000)" sketch:type="MSLayerGroup">
+                  <g id="Group-Copy-2" transform="translate(0.000000, 13.000000)">
+
+                          <linearGradient id="Oval-7-Copy-2_1_" gradientUnits="userSpaceOnUse" x1="-623.0359" y1="1019.4888" x2="-624.0359" y2="1019.5301" gradientTransform="matrix(348.2257 0 0 -87.3639 217017.5938 89569.3125)">
+                          <stop  offset="0" style="stop-color:#979797"/>
+                          <stop  offset="0.2293" style="stop-color:#F1F1F1"/>
+                          <stop  offset="0.5129" style="stop-color:#FFFFFF"/>
+                          <stop  offset="1" style="stop-color:#979797"/>
+                      </linearGradient>
+                      <path id="Oval-7-Copy-2" fill="none" stroke="url(#Oval-7-Copy-2_1_)" stroke-width="1.465" d="M-100,528.7
+                          c95.9-18.7,167.6-46.2,160.3-61.5c-7.4-15.3-91-12.6-186.9,6.1c-95.9,18.7-167.6,46.2-160.3,61.5
+                          C-279.6,550.1-195.9,547.4-100,528.7L-100,528.7z"/>
+
+                          <linearGradient id="Oval-7-Copy-3_1_" gradientUnits="userSpaceOnUse" x1="-623.0359" y1="1019.4888" x2="-624.0359" y2="1019.5301" gradientTransform="matrix(348.2257 0 0 -87.3639 217017.5938 89569.3125)">
+                          <stop  offset="0" style="stop-color:#979797"/>
+                          <stop  offset="0.1977" style="stop-color:#F1F1F1"/>
+                          <stop  offset="0.567" style="stop-color:#FFFFFF"/>
+                          <stop  offset="1" style="stop-color:#979797"/>
+                      </linearGradient>
+                      <path id="Oval-7-Copy-3" fill="none" stroke="url(#Oval-7-Copy-3_1_)" stroke-width="1.465" d="M-100,528.7
+                          c95.9-18.7,167.6-46.2,160.3-61.5c-7.4-15.3-91-12.6-186.9,6.1c-95.9,18.7-167.6,46.2-160.3,61.5
+                          C-279.6,550.1-195.9,547.4-100,528.7L-100,528.7z"/>
+                      <path id="Fill-9" fill="#E46E2E" d="M-107,555.9c-24.6,0-46-8.8-57.2-21.9c8.4,23.4,30.9,40.2,57.2,40.2s48.7-16.8,57.2-40.2
+                          C-61,547.1-82.4,555.9-107,555.9"/>
+                      <path id="Fill-10" fill="#E46E2E" d="M-107.4,470.6c24.6,0,46,8.8,57.2,21.9c-8.4-23.4-30.9-40.2-57.2-40.2
+                          s-48.7,16.8-57.2,40.2C-153.4,479.4-132,470.6-107.4,470.6"/>
+                      <path id="Fill-11" fill="#767474" d="M-150.1,587.5c-5.3,0.2-9.7-3.9-10-9.1c-0.2-5.3,3.9-9.7,9.1-10c5.3-0.2,9.7,3.9,10,9.1
+                          C-140.8,582.8-144.9,587.3-150.1,587.5z"/>
+                      <path id="Fill-12" fill="#767474" d="M-157.5,463c-3.3,0.1-6.1-2.4-6.2-5.7c-0.1-3.3,2.4-6.1,5.7-6.2c3.3-0.1,6.1,2.4,6.2,5.7
+                          S-154.2,462.8-157.5,463z"/>
+                      <path id="Fill-8" fill="#767474" d="M-62.6,455.9c-5.1,0.2-9.4-3.8-9.7-8.9c-0.2-5.1,3.8-9.5,8.9-9.7c5.1-0.2,9.4,3.8,9.7,8.9
+                          C-53.5,451.3-57.5,455.7-62.6,455.9z"/>
+                      <g id="Group-Copy-_x2B_-hub" transform="translate(0.000000, 52.000000)">
+                          <g id="Group-Copy" transform="translate(0.297974, 4.567815)">
+                              <path id="Fill-1" fill="#313940" d="M-218.3,464.2c0,5.5-0.4,7.3-1.6,8.6c-1,1.1-2.7,1.6-4.6,1.8l0.4,3.3
+                                  c2.2,0,5.3-0.8,7.2-2.6c2.1-2.1,2.8-5,2.8-9.4V445h-4.2V464.2"/>
+                              <path id="Fill-2" fill="#313940" d="M-186.9,461.7c0,2.4,0,4.5,0.2,6.3h-3.7l-0.2-3.8h-0.1c-1.1,1.9-3.5,4.3-7.7,4.3
+                                  c-3.6,0-8-2-8-10.1V445h4.2v12.7c0,4.4,1.3,7.3,5.2,7.3c2.8,0,4.8-1.9,5.5-3.8c0.2-0.6,0.4-1.4,0.4-2.1V445h4.2V461.7"/>
+                              <path id="Fill-3" fill="#313940" d="M-178.9,452.5c0-2.9-0.1-5.3-0.2-7.5h3.8l0.2,3.9h0.1c1.7-2.8,4.4-4.5,8.2-4.5
+                                  c5.6,0,9.8,4.7,9.8,11.7c0,8.3-5.1,12.3-10.5,12.3c-3.1,0-5.7-1.3-7.1-3.6h-0.1v12.5h-4.2V452.5L-178.9,452.5z M-174.8,458.6
+                                  c0,0.6,0.1,1.2,0.2,1.7c0.8,2.9,3.3,4.9,6.3,4.9c4.4,0,7-3.6,7-8.9c0-4.6-2.4-8.5-6.9-8.5c-2.9,0-5.5,2-6.4,5.2
+                                  c-0.1,0.5-0.3,1.1-0.3,1.7V458.6L-174.8,458.6z"/>
+                              <path id="Fill-4" fill="#313940" d="M-149.5,445l5.1,13.6c0.5,1.5,1.1,3.3,1.5,4.7h0.1c0.4-1.4,0.9-3.1,1.5-4.8l4.6-13.5h4.4
+                                  l-6.3,16.4c-3,7.9-5.1,11.9-7.9,14.4c-2.1,1.8-4.1,2.5-5.2,2.7l-1.1-3.5c1.1-0.3,2.4-1,3.7-2c1.1-0.9,2.6-2.5,3.5-4.7
+                                  c0.2-0.4,0.3-0.8,0.3-1c0-0.2-0.1-0.6-0.3-1.1l-8.6-21.2H-149.5"/>
+                              <path id="Fill-5" fill="#313940" d="M-121.3,438.4v6.6h6v3.2h-6v12.4c0,2.8,0.8,4.5,3.2,4.5c1.1,0,1.9-0.1,2.4-0.3l0.2,3.1
+                                  c-0.8,0.3-2.1,0.6-3.7,0.6c-2,0-3.5-0.6-4.5-1.8c-1.2-1.2-1.6-3.3-1.6-6v-12.5h-3.6V445h3.6v-5.5L-121.3,438.4"/>
+                              <path id="Fill-6" fill="#313940" d="M-107.5,457.3c0.1,5.7,3.7,8,7.9,8c3,0,4.8-0.5,6.4-1.2l0.7,3c-1.5,0.7-4,1.4-7.7,1.4
+                                  c-7.1,0-11.4-4.7-11.4-11.6c0-6.9,4.1-12.4,10.9-12.4c7.6,0,9.6,6.6,9.6,10.8c0,0.9-0.1,1.5-0.1,1.9H-107.5L-107.5,457.3z
+                                   M-95.2,454.3c0-2.7-1.1-6.8-5.8-6.8c-4.3,0-6.1,3.9-6.5,6.8H-95.2L-95.2,454.3z"/>
+                              <path id="Fill-7" fill="#313940" d="M-84.9,452.2c0-2.7,0-5-0.2-7.2h3.7l0.1,4.5h0.2c1.1-3.1,3.6-5,6.4-5c0.5,0,0.8,0,1.2,0.1
+                                  v3.9c-0.4-0.1-0.9-0.1-1.4-0.1c-3,0-5.1,2.2-5.6,5.4c-0.1,0.6-0.2,1.2-0.2,1.9V468h-4.2V452.2"/>
+                          </g>
+                          <path id="hub" fill="#999999" d="M-65.6,472.5h4.1v-13.7c0-0.8,0-1.4,0.3-2c0.7-2.2,2.9-4.1,5.5-4.1c3.9,0,5.2,3.1,5.2,6.7v13
+                              h4.1v-13.5c0-7.8-4.9-9.7-7.9-9.7c-1.5,0-3,0.5-4.2,1.2c-1.3,0.7-2.3,1.7-2.9,2.9h-0.1v-14.1h-4.1V472.5z M-20.7,449.9h-4.1
+                              v13.9c0,0.7-0.1,1.5-0.4,2.1c-0.7,1.8-2.7,3.7-5.4,3.7c-3.7,0-5.1-2.9-5.1-7.2v-12.5h-4.1v13.2c0,7.9,4.3,9.9,7.8,9.9
+                              c4,0,6.4-2.4,7.5-4.2h0.1l0.2,3.7h3.6c-0.1-1.8-0.2-3.8-0.2-6.2V449.9z M-10.5,472.5l0.2-3.7h0.1c1.7,3,4.3,4.3,7.6,4.3
+                              c5.1,0,10.1-4,10.1-12.1c0-6.9-3.9-11.5-9.5-11.5c-3.6,0-6.3,1.6-7.7,4.2h-0.1v-14.2h-4.1v27.4c0,2-0.1,4.3-0.2,5.8H-10.5z
+                               M-9.8,459.4c0-0.7,0.1-1.2,0.2-1.7c0.8-3.1,3.5-5.1,6.3-5.1c4.4,0,6.7,3.9,6.7,8.4c0,5.2-2.6,8.7-6.9,8.7c-3,0-5.4-2-6.2-4.8
+                              c-0.1-0.5-0.2-1-0.2-1.5V459.4z"/>
+                      </g>
+                  </g>
+              </g>
+          </g>
+      </g>
+    </svg>
+  category: Red Hat managed
+  support: red hat
+  docsLink: https://jupyter.org/hub
+  quickStart: create-jupyter-notebook
+  getStartedLink: https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html
+  getStartedMarkDown: |-
+    # Quickstart
+
+    ## Prerequisites
+
+    Before installing JupyterHub, you will need:
+
+    - a Linux/Unix based system
+    - [Python](https://www.python.org/downloads/) 3.5 or greater
+
+      An understanding
+      of using [`pip`](https://pip.pypa.io/en/stable/) or
+      [`conda`](https://conda.io/docs/get-started.html) for
+      installing Python packages is helpful.
+
+    - [nodejs/npm](https://www.npmjs.com/)
+
+      [Install nodejs/npm](https://docs.npmjs.com/getting-started/installing-node),
+      using your operating system's package manager.
+
+      - If you are using **`conda`**, the nodejs and npm dependencies will be installed for
+        you by conda.
+
+      - If you are using **`pip`**, install a recent version of
+        [nodejs/npm](https://docs.npmjs.com/getting-started/installing-node).
+        For example, install it on Linux (Debian/Ubuntu) using:
+
+        ```
+        sudo apt-get install npm nodejs-legacy
+        ```
+
+        The `nodejs-legacy` package installs the `node` executable and is currently
+        required for npm to work on Debian/Ubuntu.
+
+    - A [pluggable authentication module (PAM)](https://en.wikipedia.org/wiki/Pluggable_authentication_module)
+      to use the [default Authenticator](./getting-started/authenticators-users-basics.md)
+
+      PAM is often available by default on most distributions, if this is not the case it can be installed by
+      using the operating system's package manager.
+
+    - TLS certificate and key for HTTPS communication
+
+    - Domain name
+
+    Before running the single-user notebook servers (which may be on the same
+    system as the Hub or not), you will need:
+
+    - [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/install.html)
+      version 4 or greater
+
+    ## Installation
+
+    JupyterHub can be installed with `pip` (and the proxy with `npm`) or `conda`:
+
+    **pip, npm:**
+
+    ```bash
+    python3 -m pip install jupyterhub
+    npm install -g configurable-http-proxy
+    python3 -m pip install notebook  # needed if running the notebook servers locally
+    ```
+
+    **conda** (one command installs jupyterhub and proxy):
+
+    ```bash
+    conda install -c conda-forge jupyterhub  # installs jupyterhub and proxy
+    conda install notebook  # needed if running the notebook servers locally
+    ```
+
+    Test your installation. If installed, these commands should return the packages'
+    help contents:
+
+    ```bash
+    jupyterhub -h
+    configurable-http-proxy -h
+    ```
+
+    ## Start the Hub server
+
+    To start the Hub server, run the command:
+
+    ```bash
+    jupyterhub
+    ```
+
+    Visit `https://localhost:8000` in your browser, and sign in with your unix
+    credentials.
+
+    To **allow multiple users to sign in** to the Hub server, you must start
+    `jupyterhub` as a _privileged user_, such as root:
+
+    ```bash
+    sudo jupyterhub
+    ```
+
+    The [wiki](https://github.com/jupyterhub/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges)
+    describes how to run the server as a _less privileged user_. This requires
+    additional configuration of the system.

--- a/jupyterhub/jupyterhub/base/jupyterhub-docs.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-docs.yaml
@@ -1,0 +1,59 @@
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: jupyterhub-install-python-packages
+  annotations:
+    opendatahub.io/categories: 'AI/Machine learning,Jupyter notebook,Python'
+spec:
+  displayName: How to install Python packages on your notebook server
+  appName: jupyterhub
+  type: how-to
+  description: |-
+    Install additional python packages into your notebook server.
+  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/how_to_install_python_packages_on_your_notebook_server/index
+  durationMinutes: 15
+---
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: jupyterhub-update-server-settings
+  annotations:
+    opendatahub.io/categories: 'AI/Machine learning,Jupyter notebook,Python'
+spec:
+  displayName: How to update notebook server settings
+  type: how-to
+  appName: jupyterhub
+  description: |-
+    Update the settings or the notebook image on your notebook server.
+  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/how_to_update_notebook_server_settings/index
+  durationMinutes: 15
+---
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: jupyterhub-use-s3-bucket-data
+  annotations:
+    opendatahub.io/categories: 'AI/Machine learning,Data management,Jupyter notebook,Python'
+spec:
+  displayName: How to use data from Amazon S3 buckets
+  appName: jupyterhub
+  type: how-to
+  description: |-
+    Connect to data in S3 Storage using environment variables.
+  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/how_to_use_data_from_amazon_s3_buckets/index
+  durationMinutes: 15
+---
+apiVersion: dashboard.opendatahub.io/v1
+kind: OdhDocument
+metadata:
+  name: jupyterhub-view-installed-packages
+  annotations:
+    opendatahub.io/categories: 'AI/Machine learning,Jupyter notebook,Python'
+spec:
+  displayName: How to view installed packages on your notebook server
+  appName: jupyterhub
+  type: how-to
+  description: |-
+    See which packages are installed into your running notebook server.
+  url: https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/how_to_view_installed_packages_on_your_notebook_server/index
+  durationMinutes: 15

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -20,6 +20,10 @@ resources:
 - jupyterhub-spark-operator-configmap.yaml
 - jupyterhub-groups-configmap.yaml
 - jupyterhub-notebook-image-puller-rb.yaml
+- jupyterhub-app.yaml
+- jupyterhub-docs.yaml
+- quickstarts/create-jupyter-notebook-quickstart.yaml
+- quickstarts/deploy-python-model-quickstart.yaml
 - traefik-credentials-secret.yaml
 - traefik-configmap.yaml
 - traefik-deployment.yaml
@@ -34,7 +38,7 @@ commonLabels:
 
 configMapGenerator:
 - name: parameters
-  envs: 
+  envs:
     - params.env
 generatorOptions:
   disableNameSuffixHash: true

--- a/jupyterhub/jupyterhub/base/quickstarts/create-jupyter-notebook-quickstart.yaml
+++ b/jupyterhub/jupyterhub/base/quickstarts/create-jupyter-notebook-quickstart.yaml
@@ -1,0 +1,72 @@
+apiVersion: console.openshift.io/v1
+kind: OdhQuickStart
+metadata:
+  name: create-jupyter-notebook
+  annotations:
+    opendatahub.io/categories: 'Getting started,Jupyter notebook'
+spec:
+  displayName: Creating a Jupyter notebook
+  appName: jupyterhub
+  durationMinutes: 5
+  description: This quick start will walk you through creating a Jupyter notebook.
+  introduction: |-
+    ### This quick start shows you how to create a Jupyter notebook.
+    Red Hat® OpenShift® Data Science lets you run Jupyter notebooks on our Red Hat® OpenShift® Dedicated environment.
+
+    We have configured the JupyterHub spawner to support your amazing Data Scientist explorations and model deployments.
+
+    We just know you will absolutely love this amazing environment.  This quick start will get you working in a notebook in just a few minutes.
+  tasks:
+    - title: Launch JupyterHub
+      description: |-
+        ### To find the JupyterHub Launch action:
+        1. Click **Applications** &#x2192; **Enabled**.
+        2. Find the JupyterHub card.
+        3. Click **Launch** on the JupyterHub card to access the JupyterHub **Start a notebook server** page.
+
+        A new browser tab will open displaying the **Start a notebook server** page.
+      review:
+        instructions: |-
+          #### To verify you have launched JupyterHub:
+          Is a new **JupyterHub** browser tab visible with the **Start a notebook server** page open?
+        failedTaskHelp: This task is not verified yet. Try the task again.
+      summary:
+        success: You have launched JupyterHub.
+        failed: Try the steps again.
+    - title: Configure and start an environment
+      description: |-
+        ### Configuring and starting an environment:
+        1. Select a notebook image from the options provided.
+        2. Select a container size based on your computation needs.
+        3. Click the **Start server** button.
+
+        If you have not previously authorized the jupyterhub-hub service account to access your account, the **Authorize Access** page appears prompting you to provide authorization. Inspect the permissions selected by default, and click the **Allow selected permissions** button.
+
+        The **Start a notebook server** page will reload and indicate that the system is starting up.
+
+      review:
+        instructions: |-
+          #### To verify that you have launched the Jupyter notebook:
+          Do you see a message in the page that says **The server is starting up**?
+        failedTaskHelp: This task is not verified yet. Try the task again.
+      summary:
+        success: Your server has started and the JupyterLab interface will load shortly. When the page displays a **Stop** option, proceed to the next step.
+        failed: Try the steps again.
+    - title: Create your first notebook
+      description: |-
+        ### To create a notebook, follow these steps:
+        1. In the **Launcher** tab, under the **Notebook** heading, click the **Python 3** tile.
+        2. When the new Jupyter notebook opens, verify that you see `Python 3` in the upper right navigation bar.
+
+        You have now launched a Jupyter notebook and can begin writing Python.
+      review:
+        instructions: |-
+          #### Verify that your Jupyter notebook launched with a Python 3 kernel:
+          Is `Python 3` displaying in the upper right notification bar of your notebook?
+        failedTaskHelp:
+          This task is not verified yet. Try the task again.
+      summary:
+        success: You have created a Jupyter notebook with a Python 3 kernel!
+        failed: Try the steps again.
+  conclusion: You are now able to launch Jupyter notebooks and write Python code.  If you want to learn how to deploy a model written in Python, take the next quick start.
+  nextQuickStart: [deploy-python-model]

--- a/jupyterhub/jupyterhub/base/quickstarts/deploy-python-model-quickstart.yaml
+++ b/jupyterhub/jupyterhub/base/quickstarts/deploy-python-model-quickstart.yaml
@@ -1,0 +1,85 @@
+apiVersion: console.openshift.io/v1
+kind: OdhQuickStart
+metadata:
+  name: deploy-python-model
+  annotations:
+    opendatahub.io/categories: 'AI/Machine learning,Deployment,Jupyter notebook,Model serving,Python'
+spec:
+  displayName: Deploying a sample Python application using Flask and OpenShift.
+  appName: jupyterhub
+  durationMinutes: 10
+  description: How to deploy a Python model using Flask and OpenShift.
+  prerequisites: [You completed the "Create a Jupyter notebook" quick start.]
+  introduction: |-
+    ### This quick start shows you how to deploy a Python model.
+    Red Hat® OpenShift® Data Science makes it easy for you to deploy your data science models in a Red Hat® OpenShift® Dedicated environment.
+
+    This quick start shows you how to take your model out of a Jupyter notebook and put it into a Flask application running on OpenShift Dedicated, for use as a development sandbox.
+  tasks:
+    - title: Create a new GitHub repository using the s2i Flask template
+      description: |-
+        ### To create a new repository from the s2i Flask template:
+        1. Navigate to `https://github.com/opendatahub-io/odh-s2i-project-simple`.
+        2. Click **Use this template** to create a new repository from this template.
+        3. Enter a *Repository name* for your new repository.
+        4. Select the **Public** radio button to ensure the repository is visible.
+        5. Click **Create repository from template** to complete this step.
+
+        A new GitHub repository will be created under **Your repositories** on GitHub.
+      review:
+        instructions: |-
+          #### To verify you have create a new repository:
+          Is a new GitHub repository visible with the name you entered?
+        failedTaskHelp: This task is not verified yet. Try the task again.
+      summary:
+        success: You have created a new GitHub repository.
+        failed: Try the steps again.
+    - title: Deploy the sample Flask Python model
+      description: |-
+        ### Deploying the sample Flask application on OpenShift:
+        1. Click the **code** button from your newly created repository and copy the URL for your project.
+        2. Navigate to your OpenShift Dedicated web console and ensure you are in the **Developer** perspective.
+        3. Use the **Project** dropdown to select your OpenShift project, or create a new one.
+        4. Click **+Add**.
+        5. Click on the **From Git** card.
+        6. Paste the URL for your project (copied in step 1) into the **Git Repo URL** field. This automatically fills in some of the other fields on the page.
+        7. Under **Builder Image**, click **Python**.
+        8. Click **Create** and watch the deployment build and start in the Topology view.
+
+        The application will deploy and indicate that the system is running.
+
+      review:
+        instructions: |-
+          #### To verify that you have deployed the Flask Python model:
+          Click on the application in the Topology view and check under **Builds** in the panel that appears. You should see something like `Build #1 is complete (a minute ago)` alongside a green check mark.
+        failedTaskHelp: This task is not verified yet. Try the task again.
+      summary:
+        success: The deployed application has started.
+        failed: Try the steps again.
+    - title: Test the prediction function in the deployed model
+      description: |-
+        ### To test the sample Flask application:
+        1. Click the application in the Topology view.
+        2. In the panel that appears, copy the URL that appears under **Routes**.
+        3. In a Jupyter notebook, navigate to a terminal view.
+        4. Run this curl command, using the URL you copied in step 1.
+        ```
+        curl -X POST -d '{"hello" ":" "world"}' <URL>/predictions
+        ```
+        For example:
+        ```
+        curl -X POST -d '{"hello" ":" "world"}' http://example.apps.organization.abc3.p4.openshiftapps.com/predictions
+        ```
+
+        This should return `{"prediction":"not implemented"}` as output.
+      review:
+        instructions: |-
+          #### Verify that your deployed application is working:
+          Did you receive the response `{"prediction" '':'' "not implemented"}`?
+        failedTaskHelp:
+          This task is not verified yet. Make sure your application built correctly. Make sure you remembered to add `/predictions` to the end of the application URL to get to the endpoint.
+      summary:
+        success: You have verified that the sample model deployment is executing!
+        failed: Try the steps again.
+  conclusion: You are now able to deploy a sample model stored in GitHub.
+  nextQuickStart: []

--- a/odh-common/base/kustomization.yaml
+++ b/odh-common/base/kustomization.yaml
@@ -3,6 +3,9 @@ kind: Kustomization
 resources:
 - namespace.yaml
 - operatorgroup.yaml
+- odhapplicationcrd.yaml
+- odhdocumentcrd.yaml
+- odhquickstartcrd.yaml
 namespace: opendatahub
 commonLabels:
   opendatahub.io/component: "true"

--- a/odh-common/base/odhapplicationcrd.yaml
+++ b/odh-common/base/odhapplicationcrd.yaml
@@ -1,0 +1,164 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: odhapplications.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhApplication
+    listKind: OdhApplicationList
+    plural: odhapplications
+    singular: odhapplication
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OdhApplication is the Schema for the odhapplications
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhApplicationSpec defines the desired state of OdhApplication
+              properties:
+                beta:
+                  type: boolean
+                betaText:
+                  type: string
+                betaTitle:
+                  type: string
+                category:
+                  type: string
+                comingSoon:
+                  type: boolean
+                consoleLink:
+                  type: string
+                csvName:
+                  type: string
+                description:
+                  type: string
+                displayName:
+                  type: string
+                docsLink:
+                  type: string
+                enable:
+                  properties:
+                    actionLabel:
+                      type: string
+                    description:
+                      type: string
+                    link:
+                      type: string
+                    linkPreface:
+                      type: string
+                    title:
+                      type: string
+                    validationConfigMap:
+                      type: string
+                    validationJob:
+                      type: string
+                    validationSecret:
+                      type: string
+                    variableDisplayText:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    variableHelpText:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    variables:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                enableCR:
+                  properties:
+                    field:
+                      type: string
+                    group:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    plural:
+                      type: string
+                    value:
+                      type: string
+                    version:
+                      type: string
+                  type: object
+                endPoint:
+                  type: string
+                featureFlag:
+                  type: string
+                getStartedLink:
+                  type: string
+                getStartedMarkDown:
+                  type: string
+                img:
+                  type: string
+                isEnabled:
+                  type: boolean
+                kfdefApplications:
+                  items:
+                    type: string
+                  type: array
+                link:
+                  type: string
+                provider:
+                  type: string
+                quickStart:
+                  type: string
+                route:
+                  type: string
+                routeNamespace:
+                  type: string
+                routeSuffix:
+                  type: string
+                serviceName:
+                  type: string
+                support:
+                  type: string
+              required:
+                - description
+                - displayName
+                - docsLink
+                - getStartedLink
+                - getStartedMarkDown
+                - img
+                - provider
+                - support
+              type: object
+            status:
+              description: OdhApplicationStatus defines the observed state of OdhApplication
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/odh-common/base/odhdocumentcrd.yaml
+++ b/odh-common/base/odhdocumentcrd.yaml
@@ -1,0 +1,81 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.4.1
+  creationTimestamp: null
+  name: odhdocuments.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  names:
+    kind: OdhDocument
+    listKind: OdhDocumentList
+    plural: odhdocuments
+    singular: odhdocument
+  scope: Namespaced
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: OdhDocument is the Schema for the odhdocuments
+            API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhDocumentSpec defines the desired state of OdhDocument
+              properties:
+                appName:
+                  type: string
+                description:
+                  type: string
+                displayName:
+                  type: string
+                durationMinutes:
+                  type: integer
+                featureFlag:
+                  type: string
+                icon:
+                  type: string
+                img:
+                  type: string
+                provider:
+                  type: string
+                type:
+                  type: string
+                url:
+                  type: string
+              required:
+                - description
+                - displayName
+                - durationMinutes
+                - type
+                - url
+              type: object
+            status:
+              description: OdhDocumentStatus defines the observed state of OdhDocument
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/odh-common/base/odhquickstartcrd.yaml
+++ b/odh-common/base/odhquickstartcrd.yaml
@@ -1,0 +1,206 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: odhquickstarts.console.openshift.io
+  annotations:
+    description: Extension for guiding user through various workflows in the Red Hat
+      OpenShift Data Science dashboard.
+    displayName: OdhQuickStart
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  scope: Namespaced
+  group: console.openshift.io
+  names:
+    plural: odhquickstarts
+    singular: odhquickstart
+    kind: OdhQuickStart
+    listKind: OdhQuickStartList
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          description: OdhQuickStart is an extension for guiding user through various
+            workflows in the Red Hat OpenShift Data Science dashboard.
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: OdhQuickStartSpec is the desired quick start configuration.
+              type: object
+              required:
+                - description
+                - displayName
+                - durationMinutes
+                - introduction
+                - tasks
+              properties:
+                accessReviewResources:
+                  description: accessReviewResources contains a list of resources that
+                    the user's access will be reviewed against in order for the user
+                    to complete the Quick Start. The Quick Start will be hidden if any
+                    of the access reviews fail.
+                  type: array
+                  items:
+                    description: ResourceAttributes includes the authorization attributes
+                      available for resource requests to the Authorizer interface
+                    type: object
+                    properties:
+                      group:
+                        description: Group is the API Group of the Resource.  "*" means
+                          all.
+                        type: string
+                      name:
+                        description: Name is the name of the resource being requested
+                          for a "get" or deleted for a "delete". "" (empty) means all.
+                        type: string
+                      namespace:
+                        description: Namespace is the namespace of the action being
+                          requested.  Currently, there is no distinction between no
+                          namespace and all namespaces "" (empty) is defaulted for LocalSubjectAccessReviews
+                          "" (empty) is empty for cluster-scoped resources "" (empty)
+                          means "all" for namespace scoped resources from a SubjectAccessReview
+                          or SelfSubjectAccessReview
+                        type: string
+                      resource:
+                        description: Resource is one of the existing resource types.  "*"
+                          means all.
+                        type: string
+                      subresource:
+                        description: Subresource is one of the existing resource types.  ""
+                          means none.
+                        type: string
+                      verb:
+                        description: 'Verb is a kubernetes resource API verb, like:
+                        get, list, watch, create, update, delete, proxy.  "*" means
+                        all.'
+                        type: string
+                      version:
+                        description: Version is the API Version of the Resource.  "*"
+                          means all.
+                        type: string
+                appName:
+                  description: the name/id of the odh application the quick start pertains to
+                  type: string
+                conclusion:
+                  description: conclusion sums up the Quick Start and suggests the possible
+                    next steps. (includes markdown)
+                  type: string
+                description:
+                  description: description is the description of the Quick Start. (includes
+                    markdown)
+                  type: string
+                  maxLength: 256
+                  minLength: 1
+                displayName:
+                  description: displayName is the display name of the Quick Start.
+                  type: string
+                  minLength: 1
+                durationMinutes:
+                  description: durationMinutes describes approximately how many minutes
+                    it will take to complete the Quick Start.
+                  type: integer
+                  minimum: 1
+                icon:
+                  description: icon is a base64 encoded image that will be displayed
+                    beside the Quick Start display name. The icon should be an vector
+                    image for easy scaling. The size of the icon should be 40x40.
+                  type: string
+                introduction:
+                  description: introduction describes the purpose of the Quick Start.
+                    (includes markdown)
+                  type: string
+                  minLength: 1
+                nextQuickStart:
+                  description: nextQuickStart is a list of the following Quick Starts,
+                    suggested for the user to try.
+                  type: array
+                  items:
+                    type: string
+                prerequisites:
+                  description: prerequisites contains all prerequisites that need to
+                    be met before taking a Quick Start. (includes markdown)
+                  type: array
+                  items:
+                    type: string
+                tags:
+                  description: tags is a list of strings that describe the Quick Start.
+                  type: array
+                  items:
+                    type: string
+                tasks:
+                  description: tasks is the list of steps the user has to perform to
+                    complete the Quick Start.
+                  type: array
+                  minItems: 1
+                  items:
+                    description: OdhQuickStartTask is a single step in a Quick Start.
+                    type: object
+                    required:
+                      - description
+                      - title
+                    properties:
+                      description:
+                        description: description describes the steps needed to complete
+                          the task. (includes markdown)
+                        type: string
+                        minLength: 1
+                      review:
+                        description: review contains instructions to validate the task
+                          is complete. The user will select 'Yes' or 'No'. using a radio
+                          button, which indicates whether the step was completed successfully.
+                        type: object
+                        required:
+                          - failedTaskHelp
+                          - instructions
+                        properties:
+                          failedTaskHelp:
+                            description: failedTaskHelp contains suggestions for a failed
+                              task review and is shown at the end of task. (includes
+                              markdown)
+                            type: string
+                            minLength: 1
+                          instructions:
+                            description: instructions contains steps that user needs
+                              to take in order to validate his work after going through
+                              a task. (includes markdown)
+                            type: string
+                            minLength: 1
+                      summary:
+                        description: summary contains information about the passed step.
+                        type: object
+                        required:
+                          - failed
+                          - success
+                        properties:
+                          failed:
+                            description: failed briefly describes the unsuccessfully
+                              passed task. (includes markdown)
+                            type: string
+                            maxLength: 128
+                            minLength: 1
+                          success:
+                            description: success describes the succesfully passed task.
+                            type: string
+                            minLength: 1
+                      title:
+                        description: title describes the task and is displayed as a
+                          step heading.
+                        type: string
+                        minLength: 1

--- a/odh-dashboard/base/cluster-role-binding.yaml
+++ b/odh-dashboard/base/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+subjects:
+  - kind: ServiceAccount
+    name: odh-dashboard
+    namespace: opendatahub
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: odh-dashboard

--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -1,0 +1,38 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: odh-dashboard
+rules:
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - services
+      - configmaps
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - operator.openshift.io
+    resources:
+      - consoles

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -5,8 +5,10 @@ commonLabels:
   app.kubernetes.io/part-of: odh-dashboard
 resources:
 - role.yaml
+- cluster-role.yaml
 - service-account.yaml
 - role-binding.yaml
+- cluster-role-binding.yaml
 - deployment.yaml
 - routes.yaml
 - service.yaml

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -4,6 +4,25 @@ metadata:
   name: odh-dashboard
 rules:
   - apiGroups:
+      - dashboard.opendatahub.io
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+    resources:
+      - odhapplications
+      - odhdocuments
+  - apiGroups:
+      - console.openshift.io
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+    resources:
+      - odhquickstarts
+  - apiGroups:
       - route.openshift.io
     resources:
       - routes
@@ -20,11 +39,52 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ''
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    resources:
+      - configmaps
+      - secrets
+  - apiGroups:
+      - batch
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+    resources:
+      - cronjobs
+      - jobs
+      - jobs/status
+  - apiGroups:
+      - image.openshift.io
+    verbs:
+      - create
+      - get
+      - list
+      - patch
+      - delete
+    resources:
+      - imagestreams
+  - apiGroups:
       - build.openshift.io
     verbs:
       - get
       - list
       - watch
+      - create
+      - patch
+      - delete
     resources:
       - builds
       - buildconfigs
+      - buildconfigs/instantiate


### PR DESCRIPTION
**Fixes**: 
[ODH-496](https://issues.redhat.com/browse/ODH-496): ISV data provided in ODH Dashboard should be installed via the operator

**Analysis / Root cause**: 
Currently the ISV data (application definitions, getting started markdown, quick starts, and documentation resources) exist in yaml files that are checked into the [odh-dashboard repo](https://github.com/opendatahub-io/odh-dashboard/tree/master/data) and installed/read locally on the odh-dashboard pod.

**Solution Description**: 
Add the CRDs necessary to allow installations of the CRs for the apps, quick starts, and doc resources.
Update permissions required in order to act on these CRs.
