### PR TITLE
Add a ui configmap for jsp and enable gpu

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-ui-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-ui-configmap.yaml
@@ -1,0 +1,24 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jupyterhub-ui
+  labels:
+    jupyterhub: singleuser-profiles
+data:
+  jupyterhub-singleuser-profiles.yaml: |
+      ui:
+        gpuConfig:
+          enabled: true
+          type: dropdown
+          gpuDropdown:
+            start: 0
+        envVarConfig:
+          enabled: true
+          categories:
+          - name: AWS
+            variables:
+            - name: AWS_ACCESS_KEY_ID
+              type: password
+            - name: AWS_SECRET_ACCESS_KEY
+              type: password


### PR DESCRIPTION
This configmap will add the AWS env var category and enable the GPU dropdown by default.