### PR TITLE
Remove startingCSV

### DIFF
--- a/grafana/cluster/base/subscription.yaml
+++ b/grafana/cluster/base/subscription.yaml
@@ -9,4 +9,3 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v3.9.0

--- a/odhseldon/cluster/base/subscription.yaml
+++ b/odhseldon/cluster/base/subscription.yaml
@@ -9,4 +9,3 @@ spec:
   name: seldon-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: seldon-operator.v1.7.0

--- a/openshift-pipelines/cluster/base/subscription.yaml
+++ b/openshift-pipelines/cluster/base/subscription.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   channel: stable
   installPlanApproval: Automatic
-  startingCSV: redhat-openshift-pipelines.v1.3.1
   name: openshift-pipelines-operator-rh
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/prometheus/cluster/base/subscription.yaml
+++ b/prometheus/cluster/base/subscription.yaml
@@ -9,4 +9,3 @@ spec:
   name: prometheus
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: prometheusoperator.0.47.0

--- a/radanalyticsio/spark/cluster/base/subscription.yaml
+++ b/radanalyticsio/spark/cluster/base/subscription.yaml
@@ -9,4 +9,3 @@ spec:
   name: radanalytics-spark
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: sparkoperator.v1.1.0


### PR DESCRIPTION
Currently startingCSV's are manually set in the operator subscriptions.  This causes the operators to be installed with an older version of the operator and OLM will then slowly update the operator to the latest version of the operator available within that subscription channel.

When startingCSV is not set, OLM will select the startingCSV automatically and default to the latest version available within that subscription channel.