### PR TITLE
Update JH Cluster Role

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-cluster-role.yaml
@@ -22,3 +22,8 @@ rules:
       - ''
     resources:
       - nodes
+      - pods
+      - serviceaccounts
+      - secrets
+      - services
+      - namespaces


### PR DESCRIPTION
This commit updates cluster role for JupyterHub. This is required to access metrics from gpu-operator. These
metrics are used to determine available GPUs for a user.