### PR TITLE
Update trinio to 373

### DIFF
--- a/trino/base/kustomization.yaml
+++ b/trino/base/kustomization.yaml
@@ -140,4 +140,4 @@ images:
     newTag: 2.3.3-002
   - name: trino
     newName: quay.io/opendatahub/trino
-    newTag: '361'
+    newTag: '373'


### PR DESCRIPTION
**Related Issue**: https://github.com/opendatahub-io/odh-images/issues/14

**Description**: After the updated image of trinio is pushed into quay.io/opendatahub, this PR can be merged to bump the version in odh-manifests. Similar PR to https://github.com/operate-first/odh-manifests/pull/17/files