### PR TITLE
Jupyterhub Idle Culler update

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -74,6 +74,17 @@ Notebook Images do not provide any parameters.
 
 Notebook Images component comes with 3 overlays.
 
+#### [jupyterhub-idle-culler](jupyterhub/overlays/jupyterhub-idle-culler)
+
+Adds a `DeploymentConfig` of the jupyterhub idle culler. It enables shutting down notebooks that are idle for a certain amount of time.
+
+Changes to the culling timeout value can either be made in the `jupyterhub-cfg` `ConfigMap` or in the cluster settings section of the ODH Dashboard.
+
+**Note:** The culling timeout value in the dashboard and manual configuration fo the culler will **not** work if this overlay is deployed together with the operator, as any change to the jupyterhub-cfg `ConfigMap` will be reverted.
+
+
+Jupyterhub-idle-culler repository: https://github.com/jupyterhub/jupyterhub-idle-culler
+
 #### [additional](notebook-images/overlays/additional/)
 
 Contains additional Jupyter notebook images.

--- a/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
@@ -11,6 +11,7 @@ data:
   gpu_mode: ""
   singleuser_pvc_size: 2Gi
   notebook_destination: "$(notebook_destination)"
+  culler_timeout: "31536000" # 1 year in seconds
 
 ---
 apiVersion: v1

--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
@@ -42,6 +42,13 @@ spec:
                 configMapKeyRef:
                   name: jupyterhub-cfg
                   key: culler_timeout
+          resources:
+            limits:
+              cpu: 150m
+              memory: 50Mi
+            requests:
+              cpu: 150m
+              memory: 50Mi
           command:
             - jupyterhub-idle-culler
             - --timeout=$(CULLER_TIMEOUT)  # in seconds

--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/deploymentconfig.yaml
@@ -11,6 +11,23 @@ spec:
       labels:
         app: jupyterhub-idle-culler
     spec:
+      initContainers:
+        - name: check-for-jh
+          image: 'quay.io/odh-jupyterhub/jupyterhub-img:v0.3.3'
+          command:
+            - /bin/sh
+            - '-c'
+            - 'while ! curl jupyterhub:8081/hub/api; do sleep 5; done'
+          resources:
+            limits:
+              cpu: 150m
+              memory: 50Mi
+            requests:
+              cpu: 150m
+              memory: 20Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
       containers:
         - name: jupyterhub-idle-culler
           image: quay.io/odh-jupyterhub/jupyterhub-img:v0.3.5
@@ -20,9 +37,14 @@ spec:
                 secretKeyRef:
                   name: jupyterhub-idle-culler
                   key: token
+            - name: CULLER_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  name: jupyterhub-cfg
+                  key: culler_timeout
           command:
             - jupyterhub-idle-culler
-            - --timeout=259200  # 3 days
+            - --timeout=$(CULLER_TIMEOUT)  # in seconds
             - --url=jupyterhub:8081/hub/api
   triggers:
     - type: ConfigChange

--- a/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/kustomization.yaml
+++ b/jupyterhub/jupyterhub/overlays/jupyterhub-idle-culler/kustomization.yaml
@@ -4,5 +4,7 @@ kind: Kustomization
 commonLabels:
   app.kubernetes.io/part-of: jupyterhub
 
+bases:
+  - ../../base
 resources:
-- deploymentconfig.yaml
+  - ./deploymentconfig.yaml


### PR DESCRIPTION
This PR cherry-picks updates from downstream, as well as adds a value to the jupyterhub-cfg

Additionally it adds the content of PR https://github.com/red-hat-data-services/odh-manifests/pull/220 which adds limits and requests to the culler container.

This PR should also allow the dashboard to work with the culler, although the value change will not be applied unless the operator is scaled down.
