### PR TITLE
Update Memory limit for Dashboard

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -33,11 +33,11 @@ spec:
         - containerPort: 8080
         resources:
           requests:
-            cpu: 200m
-            memory: 100Mi
+            cpu: 500m
+            memory: 1Gi
           limits:
-            cpu: 400m
-            memory: 400Mi
+            cpu: 1000m
+            memory: 2Gi
         livenessProbe:
           httpGet:
             path: /api/status


### PR DESCRIPTION
This commits updates memory limits in Dashboard pod in order to reduce `OOMKill` errors