### PR TITLE
Add permissions required for GPU calls in dashboard

### DIFF
--- a/odh-dashboard/base/cluster-role.yaml
+++ b/odh-dashboard/base/cluster-role.yaml
@@ -71,3 +71,15 @@ rules:
       - user.openshift.io
     resources:
       - groups
+  - verbs:
+      - get
+      - list
+      - watch
+    apiGroups:
+      - ''
+    resources:
+      - pods
+      - serviceaccounts
+      - secrets
+      - services
+      - namespaces


### PR DESCRIPTION
This PR adds the neccessary permissions for the backend to communicate with prometheus service, SA and secret in the openshift-monitoring namespace.