### PR TITLE
Remove cross component configmap dependencies

### DIFF
--- a/jupyterhub/README.md
+++ b/jupyterhub/README.md
@@ -25,9 +25,57 @@ HTTP endpoint exposed by your S3 object storage solution which will be made avai
 
 Name of the storage class to be used for PVCs created by JupyterHub component. This requires `storage-class` **overlay** to be enabled as well to work.
 
-#### jupyterhub_groups_config
+#### jupyterhub_admin_groups
 
-A ConfigMap containing comma separated lists of groups which would be used as Admin and User groups for JupyterHub. The default ConfgiMap can be found [here](jupyterhub/base/jupyterhub-groups-configmap.yaml).
+A comma separated lists of groups which grants admin access for JupyterHub. The group defaults to `odh-admins`.  
+
+The `odh-admins` group does not exist by default but can be created by to grant admin rights:
+
+```yaml
+kind: Group
+apiVersion: user.openshift.io/v1
+metadata:
+  name: odh-admins
+users:
+  - user1
+  - user2
+```
+
+##### Examples
+
+This paramater can be updated to utilizing a different group by providing the paramater in the kfdef
+
+```yaml
+  - kustomizeConfig:
+      parameters:
+        - name: jupyterhub_admin_groups
+          value: <my-group>
+      repoRef:
+        name: manifests
+        path: jupyterhub/jupyterhub
+    name: jupyterhub
+```
+
+#### jupyterhub_allowed_groups
+
+A comma separated lists of groups which grants user access for JupyterHub. The group defaults to `system:authenticated`.  
+
+The `system:authenticated` group allows anyone with ability to log into the cluster the ability to access JupyterHub.
+
+##### Examples
+
+This paramater can be updated to utilizing a different group by providing the paramater in the kfdef
+
+```yaml
+  - kustomizeConfig:
+      parameters:
+        - name: jupyterhub_allowed_groups
+          value: <my-group>
+      repoRef:
+        name: manifests
+        path: jupyterhub/jupyterhub
+    name: jupyterhub
+```
 
 #### jupyterhub_secret
 

--- a/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-dc.yaml
@@ -117,12 +117,12 @@ spec:
         - name: JUPYTERHUB_ADMIN_GROUPS
           valueFrom:
             configMapKeyRef:
-              name: $(jupyterhub_groups_config)
+              name: jupyterhub-groups
               key: admin_groups
         - name: JUPYTERHUB_ALLOWED_GROUPS
           valueFrom:
             configMapKeyRef:
-              name: $(jupyterhub_groups_config)
+              name: jupyterhub-groups
               key: allowed_groups
         - name: JUPYTERHUB_CRYPT_KEY
           valueFrom:

--- a/jupyterhub/jupyterhub/base/jupyterhub-groups-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-groups-configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: jupyterhub
-  name: jupyterhub-default-groups-config
+  name: jupyterhub-groups
 data:
-  admin_groups: "odh-jupyterhub-admins"
-  allowed_groups: "system:authenticated"
+  admin_groups: $(jupyterhub_admin_groups)
+  allowed_groups: $(jupyterhub_allowed_groups)

--- a/jupyterhub/jupyterhub/base/kustomization.yaml
+++ b/jupyterhub/jupyterhub/base/kustomization.yaml
@@ -28,7 +28,6 @@ resources:
 - traefik-rolebinding.yaml
 - traefik-serviceaccount.yaml
 - traefik-service.yaml
-- groups-config.yaml
 
 commonLabels:
   opendatahub.io/component: "true"
@@ -63,13 +62,20 @@ vars:
     apiVersion: v1
   fieldref:
     fieldpath: data.s3_endpoint_url
-- name: jupyterhub_groups_config
+- name: jupyterhub_admin_groups
   objref:
     kind: ConfigMap
     name: parameters
     apiVersion: v1
   fieldref:
-    fieldpath: data.jupyterhub_groups_config
+    fieldpath: data.jupyterhub_admin_groups
+- name: jupyterhub_allowed_groups
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.jupyterhub_allowed_groups
 - name: jupyterhub_secret
   objref:
     kind: ConfigMap

--- a/jupyterhub/jupyterhub/base/params.env
+++ b/jupyterhub/jupyterhub/base/params.env
@@ -1,6 +1,7 @@
 storage_class=
 s3_endpoint_url=
-jupyterhub_groups_config=jupyterhub-default-groups-config
+jupyterhub_admin_groups=odh-admins
+jupyterhub_allowed_groups="system:authenticated"
 jupyterhub_secret=jupyterhub
 notebook_destination=
 traefik_credentials_secret=traefik-credentials

--- a/jupyterhub/jupyterhub/base/params.yaml
+++ b/jupyterhub/jupyterhub/base/params.yaml
@@ -19,7 +19,9 @@ varReference:
   kind: DeploymentConfig
 - path: data/notebook_destination
   kind: ConfigMap
-- path: data/groups-config
-  kind: ConfigMap  
+- path: data/admin_groups
+  kind: ConfigMap
+- path: data/allowed_groups
+  kind: ConfigMap
 - path: subjects/name
   kind: RoleBinding

--- a/odh-dashboard/README.md
+++ b/odh-dashboard/README.md
@@ -15,7 +15,7 @@ For more information, visit the project [GitHub repo](https://github.com/opendat
    Open Data Hub Dashboard configured to require users to authenticate to the
    OpenShift cluster before they can access the service
 
-##### Installation
+### Installation
 ```
   - kustomizeConfig:
       repoRef:
@@ -29,6 +29,41 @@ If you would like to configure the dashboard to require authentication:
   - kustomizeConfig:
       overlays:
         - authentication
+      repoRef:
+        name: manifests
+        path: odh-dashboard
+    name: odh-dashboard
+```
+
+### Admin Control Panel
+
+The ODH Dashboard has several features only accessible to admin users which requires some configuration to access.
+
+To access the admin control panel in the dashboard it is highly recommended that you deploy the dashboard with the authentication overlay.
+
+By default the ODH Dashboard utilizes an OpenShift Group object named `odh-admins` to grant access to the admin panel.  That group is not automatically deployed by ODH.  You can manually create that object:
+
+```yaml
+kind: Group
+apiVersion: user.openshift.io/v1
+metadata:
+  name: odh-admins
+users:
+  - user1
+  - user2
+```
+
+#### Configuring A Custom Admin Group
+
+If you wish to use an existing group or create a new custom group object you can add the following paramaters:
+
+```yaml
+  - kustomizeConfig:
+      overlays:
+        - authentication
+      parameters:
+        - name: odh_dashboard_admin_groups
+          value: <my-group>
       repoRef:
         name: manifests
         path: odh-dashboard

--- a/odh-dashboard/base/groups-config.yaml
+++ b/odh-dashboard/base/groups-config.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: groups-config
 data:
-  groups-config: $(jupyterhub_groups_config)
+  groups-config: odh-dashboard-groups

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -13,3 +13,29 @@ resources:
 - deployment.yaml
 - routes.yaml
 - service.yaml
+- groups-config.yaml
+- odh-dashboard-groups-configmap.yaml
+
+configMapGenerator:
+- name: parameters
+  envs: 
+    - params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: odh_dashboard_admin_groups
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh_dashboard_admin_groups
+- name: odh_dashboard_allowed_groups
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.odh_dashboard_allowed_groups
+configurations:
+- params.yaml

--- a/odh-dashboard/base/odh-dashboard-groups-configmap.yaml
+++ b/odh-dashboard/base/odh-dashboard-groups-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odh-dashboard-groups
+data:
+  admin_groups: $(odh_dashboard_admin_groups)
+  allowed_groups: $(odh_dashboard_allowed_groups)

--- a/odh-dashboard/base/params.env
+++ b/odh-dashboard/base/params.env
@@ -1,0 +1,2 @@
+odh_dashboard_admin_groups=odh-admins
+odh_dashboard_allowed_groups="system:authenticated"

--- a/odh-dashboard/base/params.yaml
+++ b/odh-dashboard/base/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: data/admin_groups
+  kind: ConfigMap
+- path: data/allowed_groups
+  kind: ConfigMap


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Resolves #604

This update makes the config maps utilized by the JupyterHub and ODH-Dashboard components unique so that each component can be deployed independently of each other.

This update also makes the group names that grant admin/user access to those components directly configurable.  Previously these items were configured by a configmap that contains the name of the configmap that contains the groups (sorry, this was confusing just trying to describe it).  The update makes the single configmap name setting into two settings that allow you to set the groups directly.  This has the benefit of being more directly configurable directly through the kfdef but also eliminates the creation of an unused configmap always being deployed if the user chooses to set a custom group (jupyterhub-default-groups-config).

Update includes README updates for new parameters and options.

## How Has This Been Tested?
Deploy KFDef with JupyterHub and ODH-Dashboard components;

```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
spec:
  applications:
    - kustomizeConfig:
        parameters:
          - name: s3_endpoint_url
            value: s3.odh.com
        repoRef:
          name: manifests
          path: jupyterhub/jupyterhub
      name: jupyterhub
    - kustomizeConfig:
        overlays:
          - authentication
        repoRef:
          name: manifests
          path: odh-dashboard
      name: odh-dashboard
  repos:
    - name: kf-manifests
      uri: >-
        https://github.com/opendatahub-io/manifests/tarball/v1.5-branch-openshift
    - name: manifests
      uri: 'https://github.com/strangiato/odh-manifests/tarball/admin-groups'
```

Validate no admin access to JupyterHub or ODH-Dashboard

Create `odh-dashboard` group with user:

```yaml
kind: Group
apiVersion: user.openshift.io/v1
metadata:
  name: odh-admins
users:
  - opentlc-mgr
```

Validate admin panels appearing in ODH-Dashboard and JupyterHub

Update kfdef with params:
```yaml
apiVersion: kfdef.apps.kubeflow.org/v1
kind: KfDef
metadata:
  name: opendatahub
spec:
  applications:
    - kustomizeConfig:
        parameters:
          - name: s3_endpoint_url
            value: s3.odh.com
          - name: jupyterhub_admin_groups
            value: test-jupyterhub-admins
        repoRef:
          name: manifests
          path: jupyterhub/jupyterhub
      name: jupyterhub
    - kustomizeConfig:
        overlays:
          - authentication
        parameters:
          - name: odh_dashboard_admin_groups
            value: test-odh-dashboard-admins
        repoRef:
          name: manifests
          path: odh-dashboard
      name: odh-dashboard
  repos:
    - name: kf-manifests
      uri: >-
        https://github.com/opendatahub-io/manifests/tarball/v1.5-branch-openshift
    - name: manifests
      uri: 'https://github.com/strangiato/odh-manifests/tarball/admin-groups'
```

Verify that admin access is gone in JupyterHub and ODH-Dashboard.

Create groups to verify that access is restored.
- test-jupyterhub-admins
- test-odh-dashboard-admins

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
