### PR TITLE
Adding a monitoring check to pipeline tests

### DIFF
--- a/tests/resources/ml-pipelines/enable-uwm.yaml
+++ b/tests/resources/ml-pipelines/enable-uwm.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true
+

--- a/tests/setup/kfctl_openshift.yaml
+++ b/tests/setup/kfctl_openshift.yaml
@@ -81,8 +81,8 @@ spec:
         - metadata-store-mysql
       repoRef:
         name: pipeline-manifests
-        path: kfp-tekton
-    name: kfp-tekton
+        path: ml-pipelines
+    name: ml-pipelines
   repos:
   - name: kf-manifests
     uri: https://github.com/opendatahub-io/manifests/tarball/master


### PR DESCRIPTION
## Description
- Added a monitoring check to pipeline tests
- Enabled user workload monitoring
- Updated the component name from `kfp-tekton` to `ml-pipelines` in the `kfctl_openshift.yaml` kfdef.

## Testing instructions

- Install the `OpenDataHub` and `OpenShift Pipelines` operators on the cluster.
- Create an `opendatahub` namespace: `oc new-project opendatahub`
- Run the following commands:
  - `make build -- to create the test container image`
  - `make run TESTS_REGEX=ml-pipelines`
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
