### PR TITLE
Remove .spec.name from GrafanaDashboards

### DIFF
--- a/grafana/grafana/base/argo-dashboards/argo-dashboard.yaml
+++ b/grafana/grafana/base/argo-dashboards/argo-dashboard.yaml
@@ -6,7 +6,6 @@ metadata:
     app: grafana
 spec:
   # Imported from https://github.com/argoproj/argo-workflows/blob/v3.2.3/examples/grafana-dashboard.json
-  name: argo-dashboard.json
   json: >
    {
           "annotations": {

--- a/grafana/grafana/base/kafka-dashboards/kafka-dashboard.yaml
+++ b/grafana/grafana/base/kafka-dashboards/kafka-dashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: kafka-dashboard.json
   json: >
     {
       "annotations": {

--- a/grafana/grafana/base/odh-notebook-controller-dashboards/odh-notebook-controller-dashboard.yaml
+++ b/grafana/grafana/base/odh-notebook-controller-dashboards/odh-notebook-controller-dashboard.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     app: grafana
 spec:
-  name: notebook-controller-dashboard.json
   json: >
     {
       "annotations": {


### PR DESCRIPTION
Fixes #616 

## Description
As the ODH operator is moving towards `server-side-apply` the validation for GrafanaDashboard fails
since .spec.name is no longer a valid field

## How Has This Been Tested?
1. Deploy custom image of ODH Operator with the change https://github.com/opendatahub-io/opendatahub-operator/pull/1712. 
2. Deploy KFDef with Grafana .

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
