### PR TITLE
Make Trino compatible with OpenShift Data Foundation

### DIFF
--- a/trino/base/hive-config.yaml
+++ b/trino/base/hive-config.yaml
@@ -150,6 +150,10 @@ data:
         <value>XXX_S3ENDPOINT_URL_PREFIX_XXXXXX_S3LOCATION_XXX/</value>
       </property>
       <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+      </property>
+      <property>
         <name>hive.metastore.db.type</name>
         <value>POSTGRES</value>
       </property>


### PR DESCRIPTION
Extended Trino configurations in order to enable Trino integration with OpenShift Data Foundation (Ceph S3).

## Description
Trino can't access S3 buckets in OpenShift Data Foundation with the current configurations. I've enabled path-style access for all requests to the S3 storage within the Hive configuration for compatibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
