### PR TITLE
Add spec.replicas field to 'notebook-controller-deployment'

### DIFF
--- a/odh-notebook-controller/kf-notebook-controller/manager/manager.yaml
+++ b/odh-notebook-controller/kf-notebook-controller/manager/manager.yaml
@@ -10,6 +10,7 @@ kind: Deployment
 metadata:
   name: deployment
 spec:
+  replicas: 1
   template:
     metadata:
       labels:


### PR DESCRIPTION
Fixes #663 

## How Has This Been Tested?

1.  Deploy ODH operator (with `serverside-apply` change)
2. Deploy [notebook-controller](https://github.com/opendatahub-io/odh-manifests/blob/master/kfdef/kfctl_odh_notebook_controller.yaml) Kfdef
3. Scale down `notebook-controller-deployment` to 0
4. Wait for deployment to scale up to 1

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
