### PR TITLE
Have etcd service select only etcd pods.

### DIFF
--- a/model-mesh/dependencies/quickstart.yaml
+++ b/model-mesh/dependencies/quickstart.yaml
@@ -15,6 +15,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: etcd
+  labels:
+    component: model-mesh-etcd
 spec:
   ports:
     - name: etcd-client-port
@@ -22,23 +24,23 @@ spec:
       protocol: TCP
       targetPort: 2379
   selector:
-    app: etcd
+    component: model-mesh-etcd
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: etcd
+    component: model-mesh-etcd
   name: etcd
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: etcd
+      component: model-mesh-etcd
   template:
     metadata:
       labels:
-        app: etcd
+        component: model-mesh-etcd
     spec:
       containers:
         - command:


### PR DESCRIPTION
Even though in their respective manifests etcd service selects on label `app: etcd` this is overwritten by this kustomization [setting](https://github.com/opendatahub-io/odh-manifests/blob/master/model-mesh/base/kustomization.yaml#L4). 

The result is the etcd service selects on all pods with the label `app: model-mesh`, this is a workaround change that will ensure etcd service only selects on etcd pods. A more robust solution would re organize the labels, and not add a broad `app: modelmesh` label on _all resources_ if the plan is to select on these labels by component.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
