### PR TITLE
Change the path to load default config file of ModelMesh 

### DIFF
--- a/model-mesh/manager/manager.yaml
+++ b/model-mesh/manager/manager.yaml
@@ -70,7 +70,7 @@ spec:
               cpu: "1"
               memory: 512Mi
           volumeMounts:
-            - mountPath: /etc/model-serving/config-defaults.yaml
+            - mountPath: /etc/model-serving/config/default
               name: config-defaults
               readOnly: true
           securityContext:


### PR DESCRIPTION

Signed-off-by: jooho <jlee@redhat.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
Upstream model mesh changed the path of default config file. This is to sync up with upstream and also odh model mesh is not running without this change (https://github.com/opendatahub-io/modelmesh-serving/pull/65). 

## How Has This Been Tested?
Test index image:  quay.io/jooholee/rhods-operator-live-catalog:1.22.0-sync


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
