### PR TITLE
FAI-957: TrustyAI inclusion

### DIFF
--- a/kfdef/trustyai.yaml
+++ b/kfdef/trustyai.yaml
@@ -1,0 +1,20 @@
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: odh-trustyai
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: trustyai-service
+      name: trustyai
+  repos:
+    - name: manifests
+      uri: https://github.com/opendatahub-io/odh-manifests/tarball/master
+  version: master

--- a/model-mesh/base/params.env
+++ b/model-mesh/base/params.env
@@ -1,7 +1,7 @@
 meshnamespace=
 monitoring-namespace=
 odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:v0.11.0-alpha
-odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.9.3-auth
+odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.11.0-alpha
 odh-modelmesh=quay.io/opendatahub/modelmesh:v0.11.0-alpha
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-gpu
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:v0.11.0-alpha

--- a/model-mesh/base/params.env
+++ b/model-mesh/base/params.env
@@ -1,7 +1,7 @@
 meshnamespace=
 monitoring-namespace=
 odh-mm-rest-proxy=quay.io/opendatahub/rest-proxy:v0.11.0-alpha
-odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.11.0-alpha
+odh-modelmesh-runtime-adapter=quay.io/opendatahub/modelmesh-runtime-adapter:v0.9.3-auth
 odh-modelmesh=quay.io/opendatahub/modelmesh:v0.11.0-alpha
 odh-openvino=quay.io/opendatahub/openvino_model_server:2022.3-gpu
 odh-modelmesh-controller=quay.io/opendatahub/modelmesh-controller:v0.11.0-alpha

--- a/model-mesh/default/config-defaults.yaml
+++ b/model-mesh/default/config-defaults.yaml
@@ -14,6 +14,7 @@
 # These are the system defaults which users can override with a user config
 podsPerRuntime: 2
 headlessService: true
+payloadProcessors: ""
 modelMeshImage:
   name: $(odh-modelmesh)
 modelMeshResources:

--- a/model-mesh/internal/base/deployment.yaml.tmpl
+++ b/model-mesh/internal/base/deployment.yaml.tmpl
@@ -60,6 +60,9 @@ spec:
             - name: MM_SERVICE_NAME
               value: {{.ServiceName}}
               # External gRPC port of the service, should match ports.containerPort
+            - name: MM_PAYLOAD_PROCESSORS
+              value: {{.PayloadProcessors}}
+              # External endpoint for a payload processing service
             - name: MM_SVC_GRPC_PORT
               value: "{{.Port}}"
             - name: WKUBE_POD_NAME

--- a/model-mesh/internal/base/deployment.yaml.tmpl
+++ b/model-mesh/internal/base/deployment.yaml.tmpl
@@ -59,10 +59,7 @@ spec:
           env:
             - name: MM_SERVICE_NAME
               value: {{.ServiceName}}
-              # External gRPC port of the service, should match ports.containerPort
-            - name: MM_PAYLOAD_PROCESSORS
-              value: {{.PayloadProcessors}}
-              # External endpoint for a payload processing service
+            # External gRPC port of the service, should match ports.containerPort
             - name: MM_SVC_GRPC_PORT
               value: "{{.Port}}"
             - name: WKUBE_POD_NAME

--- a/tests/basictests/trustyai.sh
+++ b/tests/basictests/trustyai.sh
@@ -47,7 +47,7 @@ function check_mm_resources() {
   oc project $MM_NAMESPACE
   os::cmd::try_until_text "oc get route example-sklearn-isvc" "example-sklearn-isvc" $odhdefaulttimeout $odhdefaultinterval
   INFER_ROUTE=$(oc get route example-sklearn-isvc --template={{.spec.host}}{{.spec.path}})
-  token=$(oc create token user-one -n ${MODEL_PROJECT})
+  token=$(oc create token user-one -n ${MM_NAMESPACE})
   os::cmd::try_until_text "oc get pod | grep modelmesh-serving" "5/5" $odhdefaulttimeout $odhdefaultinterval
   os::cmd::try_until_text "curl -k https://$INFER_ROUTE/infer -d @${RESOURCEDIR}/trustyai/data.json -H 'Authorization: Bearer $token' -i" "model_name"
 }

--- a/tests/basictests/trustyai.sh
+++ b/tests/basictests/trustyai.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+
+source $TEST_DIR/common
+
+MY_DIR=$(readlink -f `dirname "${BASH_SOURCE[0]}"`)
+
+source ${MY_DIR}/../util
+RESOURCEDIR="${MY_DIR}/../resources"
+
+TEST_USER=${OPENSHIFT_TESTUSER_NAME:-"admin"} #Username used to login to the ODH Dashboard
+TEST_PASS=${OPENSHIFT_TESTUSER_PASS:-"admin"} #Password used to login to the ODH Dashboard
+OPENSHIFT_OAUTH_ENDPOINT="https://$(oc get route -n openshift-authentication   oauth-openshift -o json | jq -r '.spec.host')"
+MM_NAMESPACE="${ODHPROJECT}-model"
+
+
+os::test::junit::declare_suite_start "$MY_SCRIPT"
+
+function get_authentication(){
+  header "Getting authentication credentials to cluster"
+  oc adm policy add-role-to-user view -n ${ODHPROJECT} --rolebinding-name "view-$TEST_USER" $TEST_USER
+  TESTUSER_BEARER_TOKEN="$(curl -kiL -u $TEST_USER:$TEST_PASS 'X-CSRF-Token: xxx' $OPENSHIFT_OAUTH_ENDPOINT'/oauth/authorize?response_type=token&client_id=openshift-challenging-client' | grep -oP 'access_token=\K[^&]*')"
+}
+
+function check_trustyai_resources() {
+  header "Checking that TrustyAI resources have spun up"
+  oc project $ODHPROJECT
+  os::cmd::try_until_text "oc get deployment modelmesh-controller" "modelmesh-controller" $odhdefaulttimeout $odhdefaultinterval
+  os::cmd::try_until_text "oc get deployment trustyai-service" "trustyai-service" $odhdefaulttimeout $odhdefaultinterval
+  os::cmd::try_until_text "oc get route trustyai-service-route" "trustyai-service-route" $odhdefaulttimeout $odhdefaultinterval
+
+  oc wait --for=condition=Ready $(oc get pod -o name | grep trustyai) --timeout=${odhdefaulttimeout}ms
+}
+
+function deploy_model() {
+    header "Deploying model into ModelMesh"
+    oc new-project $MM_NAMESPACE || true
+    os::cmd::expect_success "oc project $MM_NAMESPACE"
+    oc label namespace $MM_NAMESPACE "modelmesh-enabled=true" --overwrite=true || echo "Failed to apply modelmesh-enabled label."
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/secret.yaml -n ${MM_NAMESPACE}"
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/odh-mlserver-0.x.yaml  -n ${MM_NAMESPACE}"
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/model.yaml  -n ${MM_NAMESPACE}"
+}
+
+function check_mm_resources() {
+  header "Checking that ModelMesh resources have spun up"
+  oc project $MM_NAMESPACE
+  os::cmd::try_until_text "oc get route example-sklearn-isvc" "example-sklearn-isvc" $odhdefaulttimeout $odhdefaultinterval
+  INFER_ROUTE=$(oc get route example-sklearn-isvc --template={{.spec.host}}{{.spec.path}})
+  os::cmd::try_until_text "oc get pod | grep modelmesh-serving" "5/5" $odhdefaulttimeout $odhdefaultinterval
+  os::cmd::try_until_text "curl -k https://$INFER_ROUTE/infer -d @${RESOURCEDIR}/trustyai/data.json -H 'Authorization: Bearer $TESTUSER_BEARER_TOKEN' -i" "example-sklearn-isvc"
+}
+
+function check_communication(){
+    header "Check communication between TrustyAI and ModelMesh"
+    oc project $MM_NAMESPACE
+
+    # send some data to modelmesh
+    os::cmd::expect_success_and_text "curl -k https://$INFER_ROUTE/infer -d @${RESOURCEDIR}/trustyai/data.json -H 'Authorization: Bearer $TESTUSER_BEARER_TOKEN' -i" "model_name"
+    oc project ${ODHPROJECT}
+    os::cmd::try_until_text "oc logs $(oc get pods -o name | grep trustyai-service)" "Received partial input payload" $odhdefaulttimeout $odhdefaultinterval
+}
+
+function generate_data(){
+    header "Generate some data for TrustyAI (this will take a sec)"
+    oc project $MM_NAMESPACE
+
+    # send a bunch of random data to the model
+    DIVISOR=128.498 # divide bash's $RANDOM by this to get a float range of [0.,255.], for MNIST
+    for i in {1..500};
+    do
+      DATA=$(sed "s/\[40.83, 3.5, 0.5, 0\]/\[$(($RANDOM % 2)),$(($RANDOM / 128)),$(($RANDOM / 128)), $(($RANDOM / 128)) \]/" ${RESOURCEDIR}/trustyai/data.json)
+      curl -k https://$INFER_ROUTE/infer -d "$DATA"  -H 'Authorization: Bearer '$TESTUSER_BEARER_TOKEN -i >/dev/null 2>&1
+    done
+}
+
+function schedule_and_check_request(){
+  header "Create a metric request and confirm calculation"
+  oc project $ODHPROJECT
+  TRUSTY_ROUTE=$(oc get route/trustyai --template={{.spec.host}})
+
+  os::cmd::expect_success_and_text "curl --location http://$TRUSTY_ROUTE/metrics/spd/request \
+    --header 'Content-Type: application/json' \
+    --data '{
+        \"modelId\": \"example-sklearn-isvc\",
+        \"protectedAttribute\": \"input-0\",
+        \"favorableOutcome\": {
+            \"type\": \"INT64\",
+            \"value\": 0.0
+        },
+        \"outcomeName\": \"output-0\",
+        \"privilegedAttribute\": {
+            \"type\": \"DOUBLE\",
+            \"value\": 0.0
+        },
+        \"unprivilegedAttribute\": {
+            \"type\": \"DOUBLE\",
+            \"value\": 1.0
+        }
+    }'" "requestId"
+  os::cmd::try_until_text "curl http://$TRUSTY_ROUTE/q/metrics" "trustyai_spd"
+}
+
+
+function test_prometheus_scraping(){
+    header "Ensure metrics are in Prometheus"
+    MODEL_MONITORING_ROUTE=$(oc get route -n ${ODHPROJECT} odh-model-monitoring --template={{.spec.host}})
+    os::cmd::try_until_text "curl -k --location -g --request GET 'https://'$MODEL_MONITORING_ROUTE'//api/v1/query?query=trustyai_spd' -H 'Authorization: Bearer $TESTUSER_BEARER_TOKEN' -i" "value" $odhdefaulttimeout $odhdefaultinterval
+}
+
+function teardown_trustyai_test() {
+  header "Cleaning up the TrustyAI test"
+  oc project $ODHPROJECT
+
+  REQUEST_ID="$(curl http://$TRUSTY_ROUTE/metrics/spd/requests | jq '.requests [0].id')"
+
+  os::cmd::expect_success_and_text "curl -X DELETE --location http://$TRUSTY_ROUTE/metrics/spd/request \
+    -H 'Content-Type: application/json' \
+    -d '{
+          \"requestId\": \"'"$REQUEST_ID"'\"
+        }'" "Removed"
+
+  oc project $MM_NAMESPACE
+  os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/secret.yaml"
+  os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/odh-mlserver-0.x.yaml"
+  os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/model.yaml"
+  os::cmd::expect_success "oc delete project $MM_NAMESPACE"
+
+}
+
+get_authentication
+deploy_model
+check_mm_resources
+check_communication
+generate_data
+schedule_and_check_request
+teardown_trustyai_test
+
+
+os::test::junit::declare_suite_end

--- a/tests/resources/trustyai/data.json
+++ b/tests/resources/trustyai/data.json
@@ -1,0 +1,10 @@
+{
+  "inputs": [
+    {
+      "name": "predict",
+      "shape": [1, 4],
+      "datatype": "FP64",
+      "data": [40.83, 3.5, 0.5, 0]
+    }
+  ]
+}

--- a/tests/resources/trustyai/model.yaml
+++ b/tests/resources/trustyai/model.yaml
@@ -1,0 +1,13 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: example-sklearn-isvc
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      runtime: mlserver-0.x
+      storageUri: "https://github.com/trustyai-explainability/trustyai-explainability/raw/main/explainability-service/demo/models/model.joblib?raw=true"

--- a/tests/resources/trustyai/odh-mlserver-0.x.yaml
+++ b/tests/resources/trustyai/odh-mlserver-0.x.yaml
@@ -1,0 +1,77 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: mlserver-0.x
+  annotations:
+    enable-route: "true"
+  labels:
+    name: modelmesh-serving-mlserver-0.x-SR
+spec:
+  supportedModelFormats:
+    - name: sklearn
+      version: "0" # v0.23.1
+      autoSelect: true
+    - name: xgboost
+      version: "1" # v1.1.1
+      autoSelect: true
+    - name: lightgbm
+      version: "3" # v3.2.1
+      autoSelect: true
+
+  protocolVersions:
+    - grpc-v2
+  multiModel: true
+
+  grpcEndpoint: "port:8085"
+  grpcDataEndpoint: "port:8001"
+
+  containers:
+    - name: mlserver
+      image: quay.io/opendatahub/mlserver:0.5.2
+      env:
+        - name: MLSERVER_MODELS_DIR
+          value: "/models/_mlserver_models/"
+        - name: MLSERVER_GRPC_PORT
+          value: "8001"
+        # default value for HTTP port is 8080 which conflicts with MMesh's
+        # Litelinks port
+        - name: MLSERVER_HTTP_PORT
+          value: "8002"
+        - name: MLSERVER_LOAD_MODELS_AT_STARTUP
+          value: "false"
+        # Set a dummy model name via environment so that MLServer doesn't
+        # error on a RepositoryIndex call when no models exist
+        - name: MLSERVER_MODEL_NAME
+          value: dummy-model-fixme
+        # Set server addr to localhost to ensure MLServer only listen inside the pod
+        - name: MLSERVER_HOST
+          value: "127.0.0.1"
+        # Increase gRPC max message size to support larger payloads
+        # Unlimited because it will be restricted at the model mesh layer
+        - name: MLSERVER_GRPC_MAX_MESSAGE_LENGTH
+          value: "-1"
+      resources:
+        requests:
+          cpu: 500m
+          memory: 1Gi
+        limits:
+          cpu: "5"
+          memory: 1Gi
+  builtInAdapter:
+    serverType: mlserver
+    runtimeManagementPort: 8001
+    memBufferBytes: 134217728
+    modelLoadingTimeoutMillis: 90000

--- a/tests/resources/trustyai/openvino-inference-service.yaml
+++ b/tests/resources/trustyai/openvino-inference-service.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: example-sklearn-isvc
+  annotations:
+    serving.kserve.io/deploymentMode: ModelMesh
+spec:
+  predictor:
+    model:
+      modelFormat:
+        name: sklearn
+      runtime: mlserver-0.x
+      storage:
+        key: aws-connection-minio-data-connection
+        path: sklearn/model.joblib

--- a/tests/resources/trustyai/sample-minio.yaml
+++ b/tests/resources/trustyai/sample-minio.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  ports:
+    - name: minio-client-port
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    app: minio
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: minio
+    maistra.io/expose-route: 'true'
+  annotations:
+    sidecar.istio.io/inject: 'true'
+  name: minio
+spec:
+  containers:
+    - args:
+        - server
+        - /data1
+      env:
+        - name: MINIO_ACCESS_KEY
+          value:  THEACCESSKEY
+        - name: MINIO_SECRET_KEY
+          value: THESECRETKEY
+      image: quay.io/trustyai/modelmesh-minio-examples:latest
+      name: minio
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-connection-minio-data-connection
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/managed: 'true'
+  annotations:
+    opendatahub.io/connection-type: s3
+    openshift.io/display-name: Minio Data Connection
+data:
+  AWS_ACCESS_KEY_ID: VEhFQUNDRVNTS0VZ
+  AWS_DEFAULT_REGION: dXMtc291dGg=
+  AWS_S3_BUCKET: bW9kZWxtZXNoLWV4YW1wbGUtbW9kZWxz
+  AWS_S3_ENDPOINT: aHR0cDovL21pbmlvOjkwMDA=
+  AWS_SECRET_ACCESS_KEY: VEhFU0VDUkVUS0VZ
+type: Opaque

--- a/tests/resources/trustyai/secret.yaml
+++ b/tests/resources/trustyai/secret.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-connection-minio-data-connection
+  labels:
+    opendatahub.io/dashboard: 'true'
+    opendatahub.io/managed: 'true'
+  annotations:
+    opendatahub.io/connection-type: s3
+    openshift.io/display-name: Minio Data Connection
+data:
+  AWS_ACCESS_KEY_ID: VEhFQUNDRVNTS0VZ
+  AWS_DEFAULT_REGION: dXMtc291dGg=
+  AWS_S3_BUCKET: bW9kZWxtZXNoLWV4YW1wbGUtbW9kZWxz
+  AWS_S3_ENDPOINT: aHR0cDovL21pbmlvOjkwMDA=
+  AWS_SECRET_ACCESS_KEY: VEhFU0VDUkVUS0VZ
+type: Opaque
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: model-serving-etcd
+stringData:
+  etcd_connection: |
+    {
+      "endpoints": "http://etcd:2379",
+      "root_prefix": "modelmesh-serving",
+      "userid": "root",
+      "password": "<etcd_password>"
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-passwords
+stringData:
+  root: <etcd_password>

--- a/tests/resources/trustyai/service_account.yaml
+++ b/tests/resources/trustyai/service_account.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: user-one
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: user-one-view
+subjects:
+  - kind: ServiceAccount
+    name: user-one
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view

--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -23,9 +23,11 @@ echo `oc version`
 if [ -z "${SKIP_INSTALL}" ]; then
     # This is needed to avoid `oc status` failing inside openshift-ci
     oc new-project ${ODHPROJECT}
+    oc project ${ODHPROJECT} # in case a new project is not created
     $HOME/peak/install.sh
     echo "Sleeping for 5 min to let the KfDef install settle"
     sleep 5m
+
     # Save the list of events and pods that are running prior to the test run
     oc get events --sort-by='{.lastTimestamp}' > ${ARTIFACT_DIR}/pretest-${ODHPROJECT}.events.txt
     oc get pods -o yaml -n ${ODHPROJECT} > ${ARTIFACT_DIR}/pretest-${ODHPROJECT}.pods.yaml

--- a/tests/setup/odh-core.yaml
+++ b/tests/setup/odh-core.yaml
@@ -55,13 +55,6 @@ spec:
     name: notebook-images
   - kustomizeConfig:
       overlays:
-        - odh-model-controller
-      repoRef:
-        name: manifests
-        path: model-mesh
-    name: model-mesh
-  - kustomizeConfig:
-      overlays:
         - metadata-store-mariadb
         - ds-pipeline-ui
         - object-store-minio
@@ -88,6 +81,11 @@ spec:
         name: manifests
         path: modelmesh-monitoring
     name: modelmesh-monitoring
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: trustyai-service
+    name: trustyai
   - kustomizeConfig:
       repoRef:
         name: manifests

--- a/trustyai-service/OWNERS
+++ b/trustyai-service/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+  - robgeada
+  - ruivieira
+  - tteofili
+  
+approvers:
+  - robgeada
+  - ruivieira
+  - tteofili

--- a/trustyai-service/README.md
+++ b/trustyai-service/README.md
@@ -1,0 +1,38 @@
+# TrustyAI Service
+
+TrustyAI is a service to provide fairness metrics to ModelMesh served models.
+
+
+### Installation process
+
+Following are the steps to install Model Mesh as a part of OpenDataHub install:
+
+1. Install the OpenDataHub operator
+2. Create a KfDef that includes the model-mesh component with the odh-model-controller overlay.
+3. Set the `payloadProcessor` value within `model-serving-config-defaults` ConfigMap
+to `http://trustyai-service/consumer/kserve/v2`
+4. Create a TrustyAI KfDef:
+```
+apiVersion: kfdef.apps.kubeflow.org/v1
+kind: KfDef
+metadata:
+  name: odh-trustyai
+spec:
+  applications:
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: odh-common
+      name: odh-common
+    - kustomizeConfig:
+        repoRef:
+          name: manifests
+          path: trustyai-service
+      name: trustyai
+  repos:
+    - name: manifests
+      uri: https://api.github.com/repos/opendatahub-io/odh-manifests/tarball/master
+  version: master
+
+```
+

--- a/trustyai-service/base/kustomization.yaml
+++ b/trustyai-service/base/kustomization.yaml
@@ -7,3 +7,6 @@ resources:
 - ../default
 - ../servicemonitors
 - trustyai-configmap.yaml
+- route.yaml
+- pvc.yaml
+- secret.yaml

--- a/trustyai-service/base/kustomization.yaml
+++ b/trustyai-service/base/kustomization.yaml
@@ -9,4 +9,3 @@ resources:
 - trustyai-configmap.yaml
 - route.yaml
 - pvc.yaml
-- secret.yaml

--- a/trustyai-service/base/kustomization.yaml
+++ b/trustyai-service/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: trustyai
+  app.kubernetes.io/part-of: trustyai
+resources:
+- ../default
+- ../servicemonitors
+- trustyai-configmap.yaml

--- a/trustyai-service/base/pvc.yaml
+++ b/trustyai-service/base/pvc.yaml
@@ -1,0 +1,11 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: trustyai-service-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  volumeMode: Filesystem

--- a/trustyai-service/base/route.yaml
+++ b/trustyai-service/base/route.yaml
@@ -1,7 +1,7 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
-  name: trustyai-service-route
+  name: trustyai
   labels:
     app: trustyai
     app.kubernetes.io/name: trustyai-service
@@ -13,7 +13,5 @@ spec:
     kind: Service
     name: trustyai-service
   port:
-    targetPort: https
-  tls:
-    termination: reencrypt
-    insecureEdgeTerminationPolicy: Redirect
+    targetPort: http
+  tls: null

--- a/trustyai-service/base/route.yaml
+++ b/trustyai-service/base/route.yaml
@@ -1,0 +1,19 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: trustyai-service-route
+  labels:
+    app: trustyai
+    app.kubernetes.io/name: trustyai-service
+    app.kubernetes.io/part-of: trustyai
+    app.kubernetes.io/version: 0.1.0
+    app.openshift.io/runtime: quarkus
+spec:
+  to:
+    kind: Service
+    name: trustyai-service
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+    insecureEdgeTerminationPolicy: Redirect

--- a/trustyai-service/base/secret.yaml
+++ b/trustyai-service/base/secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: trustyai-service-oauth-config
-  annotations:
-    secret-generator.opendatahub.io/name: "cookie_secret"
-    secret-generator.opendatahub.io/type: "oauth"
-    secret-generator.opendatahub.io/complexity: "16"

--- a/trustyai-service/base/secret.yaml
+++ b/trustyai-service/base/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: trustyai-service-oauth-config
+  annotations:
+    secret-generator.opendatahub.io/name: "cookie_secret"
+    secret-generator.opendatahub.io/type: "oauth"
+    secret-generator.opendatahub.io/complexity: "16"

--- a/trustyai-service/base/trustyai-configmap.yaml
+++ b/trustyai-service/base/trustyai-configmap.yaml
@@ -1,0 +1,12 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: trustyai-config
+data:
+  service_storage_format: "PVC"
+  service_data_format: "CSV"
+  service_metrics_schedule: "5s"
+  service_batch_size: "5000"
+  storage_data_filename: "data.csv"
+  storage_data_folder: "/inputs"
+

--- a/trustyai-service/default/kustomization.yaml
+++ b/trustyai-service/default/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - trustyai-deployment.yaml

--- a/trustyai-service/default/trustyai-deployment.yaml
+++ b/trustyai-service/default/trustyai-deployment.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: <<unknown>>
+    app.quarkus.io/commit-id: 0acbb40970b5c0dd7e5a50966d6b3d68e137be10
+    app.quarkus.io/build-timestamp: 2023-02-24 - 13:56:14 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app.kubernetes.io/name: trustyai-service
+    app.kubernetes.io/version: 0.1.0
+    app.openshift.io/runtime: quarkus
+  name: trustyai-service
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: trustyai-service
+    app.kubernetes.io/version: 0.1.0
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    app.openshift.io/vcs-url: <<unknown>>
+    app.quarkus.io/commit-id: ea73183a2c1b81bd9afe31005644d374b5bdeb34
+    app.quarkus.io/build-timestamp: 2023-02-15 - 15:41:47 +0000
+    prometheus.io/scrape: "true"
+    prometheus.io/path: /q/metrics
+    prometheus.io/port: "8080"
+    prometheus.io/scheme: http
+  labels:
+    app.openshift.io/runtime: quarkus
+    app.kubernetes.io/version: 0.1.0
+    app.kubernetes.io/name: trustyai-service
+    app.kubernetes.io/version: 0.1.0
+    app.openshift.io/runtime: quarkus
+  name: trustyai-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/version: 0.1.0
+      app.kubernetes.io/name: trustyai-service
+  template:
+    metadata:
+      annotations:
+        app.openshift.io/vcs-url: <<unknown>>
+        app.quarkus.io/commit-id: ea73183a2c1b81bd9afe31005644d374b5bdeb34
+        app.quarkus.io/build-timestamp: 2023-02-15 - 15:41:47 +0000
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /q/metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scheme: http
+      labels:
+        app.openshift.io/runtime: quarkus
+        app.kubernetes.io/version: 0.1.0
+        app.kubernetes.io/name: trustyai-service
+    spec:
+      initContainers:
+        - name: config-map-overrider
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
+          command: [ "/bin/bash", "-c", "--" ]
+          args:
+            - |
+              # ugly hack: write a configmap that knows its own namespace
+              echo "apiVersion: v1" > /tmp/model-serving-config.yaml
+              echo "kind: ConfigMap" >> /tmp/model-serving-config.yaml
+              echo "metadata:" >> /tmp/model-serving-config.yaml
+              echo "  name: model-serving-config" >> /tmp/model-serving-config.yaml
+              echo "data:" >> /tmp/model-serving-config.yaml
+              echo "  config.yaml: |" >> /tmp/model-serving-config.yaml
+              
+              current_namespace=$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)
+              
+              echo "    payloadProcessors: "http://trustyai-service.$current_namespace/consumer/kserve/v2"" >> /tmp/model-serving-config.yaml
+              cat /tmp/model-serving-config.yaml
+              oc apply -f /tmp/model-serving-config.yaml
+              exit 0
+      containers:
+        - env:
+            - name: STORAGE_DATA_FILENAME
+              valueFrom:
+                configMapKeyRef:
+                  key: storage_data_filename
+                  name: trustyai-config
+            - name: SERVICE_STORAGE_FORMAT
+              valueFrom:
+                configMapKeyRef:
+                  key: service_storage_format
+                  name: trustyai-config
+            - name: STORAGE_DATA_FOLDER
+              valueFrom:
+                configMapKeyRef:
+                  key: storage_data_folder
+                  name: trustyai-config
+            - name: SERVICE_BATCH_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  key: service_batch_size
+                  name: trustyai-config
+            - name: SERVICE_DATA_FORMAT
+              valueFrom:
+                configMapKeyRef:
+                  key: service_data_format
+                  name: trustyai-config
+            - name: SERVICE_METRICS_SCHEDULE
+              valueFrom:
+                configMapKeyRef:
+                  key: service_metrics_schedule
+                  name: trustyai-config
+          image: quay.io/trustyai/trustyai-service:0.1.0
+          imagePullPolicy: Always
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/live
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: trustyai-service
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /q/health/ready
+              port: 8080
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 10
+          volumeMounts:
+            - mountPath: /inputs
+              name: volume
+              readOnly: false
+      serviceAccountName: trustyai-serviceaccount
+      volumes:
+        - name: volume
+          persistentVolumeClaim:
+            claimName: trustyai-service-pvc
+            readOnly: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: trustyai-serviceaccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trustyai-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trustyai-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trustyai-role
+subjects:
+  - kind: ServiceAccount
+    name: trustyai-serviceaccount

--- a/trustyai-service/default/trustyai-deployment.yaml
+++ b/trustyai-service/default/trustyai-deployment.yaml
@@ -10,6 +10,7 @@ metadata:
     prometheus.io/path: /q/metrics
     prometheus.io/port: "8080"
     prometheus.io/scheme: http
+    service.alpha.openshift.io/serving-cert-secret-name: trustyai-service-proxy-tls
   labels:
     app.kubernetes.io/name: trustyai-service
     app.kubernetes.io/version: 0.1.0
@@ -148,11 +149,13 @@ spec:
               name: volume
               readOnly: false
       serviceAccountName: trustyai-serviceaccount
+
       volumes:
         - name: volume
           persistentVolumeClaim:
             claimName: trustyai-service-pvc
             readOnly: false
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/trustyai-service/servicemonitors/kustomization.yaml
+++ b/trustyai-service/servicemonitors/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - trustyai-metrics.yaml

--- a/trustyai-service/servicemonitors/trustyai-metrics.yaml
+++ b/trustyai-service/servicemonitors/trustyai-metrics.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: trustyai-metrics
+  labels:
+    modelmesh-service: modelmesh-serving
+spec:
+  endpoints:
+    - interval: 30s
+      path: /q/metrics
+      honorLabels: true
+      honorTimestamps: true
+      scrapeTimeout: 10s
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      targetPort: 8080
+      scheme: http
+      params:
+        'match[]':
+          - '{__name__= "trustyai_spd"}'
+          - '{__name__= "trustyai_dir"}'
+      metricRelabelings:
+        - action: keep
+          regex: trustyai_.*
+          sourceLabels:
+            - __name__
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: trustyai-service


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
- Added TrustyAI manifests to trustyai directory
- Added TrustyAI overlay to modelmesh, to select specific trustyai modelmesh repo

## How Has This Been Tested?
The E2E test in [the TrustyAI downstream repo](https://github.com/red-hat-data-services/trustyai-explainability/tree/main/e2e_tests)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

Testing instructions:
1) Install the ODH operator into your cluster
2) `git clone https://github.com/red-hat-data-services/trustyai-explainability`
3) Run the E2E test from the [the TrustyAI downstream repo](https://github.com/red-hat-data-services/trustyai-explainability/tree/main/e2e_tests): ./odh-deployment-e2e.sh robgeada FAI-957-trustyai