### PR TITLE
Fix ds-pipeline-viewer-crd-service-account authorization to add final…

### DIFF
--- a/data-science-pipelines/overlays/component-visualization-server/roles/ds-pipeline-viewer-controller.yaml
+++ b/data-science-pipelines/overlays/component-visualization-server/roles/ds-pipeline-viewer-controller.yaml
@@ -22,6 +22,7 @@ rules:
       - kubeflow.org
     resources:
       - viewers
+      - viewers/finalizers
     verbs:
       - create
       - get


### PR DESCRIPTION
…izer on owned deployments

Allow ds-pipeline-viewer-crd-service-account to add finalizers on the deployments it creates.

## Description
With current role and rolebinding, the service account cannot add a finalizer on their deployments. Therefore the deployment fail and we have an error on the ds-pipeline-viewer-crd: "cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on".
Also, I found out that upstream Kubeflow Pipeline also add this resource to the role: https://github.com/kubeflow/pipelines/blob/master/manifests/kustomize/base/pipeline/ml-pipeline-viewer-crd-role.yaml.

## How Has This Been Tested?
Tested manually only. But upstream have same settings Kubeflow Pipeline
