### PR TITLE
Integrate TrustyAI notebook into ODH

### DIFF
--- a/notebook-images/base/jupyter-trustyai-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-trustyai-notebook-imagestream.yaml
@@ -1,0 +1,25 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com//opendatahub-io/notebooks/tree/main/jupyter/trustyai"
+    opendatahub.io/notebook-image-name: "TrustyAI"
+    opendatahub.io/notebook-image-desc: "Jupyter TrustyAI notebook integrates the TrustyAI Explainability Toolkit on Jupyter environment."
+    opendatahub.io/notebook-image-order: "6"
+  name: jupyter-trustyai-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"TrustyAI","version":"0.2"}, {"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
+      openshift.io/imported-from: quay.io/opendatahub/workbench-images
+    from:
+      kind: DockerImage
+      name: quay.io/opendatahub/workbench-images:jupyter-trustyai-ubi9-python-3.9-2023a-weekly
+    name: "2023.1"
+    referencePolicy:
+      type: Local

--- a/notebook-images/base/kustomization.yaml
+++ b/notebook-images/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - jupyter-minimal-gpu-notebook-imagestream.yaml
 - jupyter-pytorch-notebook-imagestream.yaml
 - jupyter-tensorflow-notebook-imagestream.yaml
+- jupyter-trustyai-notebook-imagestream.yaml
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: notebooks

--- a/tests/resources/notebook-controller/notebooks/jupyter-trustyai-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/jupyter-trustyai-ubi9-python-3-9.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kubeflow.org/v1
+kind: Notebook
+metadata:
+  name: jupyter-trustyai-ubi9-python-3-9
+  annotations:
+    notebooks.opendatahub.io/inject-oauth: "true"
+spec:
+  template:
+    spec:
+      containers:
+        - name: jupyter-trustyai-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-trustyai-notebook:2023.1
+          imagePullPolicy: Always
+          workingDir: /opt/app-root/src
+          env:
+            - name: NOTEBOOK_ARGS
+              value: |
+                --ServerApp.port=8888
+                --ServerApp.token=''
+                --ServerApp.password=''
+                --ServerApp.base_url=/notebook/opendatahub/jupyter-trustyai-ubi9-python-3-9
+          ports:
+            - name: notebook-port
+              containerPort: 8888
+              protocol: TCP
+          resources:
+            requests:
+              cpu: "1"
+              memory: 1Gi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              scheme: HTTP
+              path: /notebook/opendatahub/jupyter-trustyai-ubi9-python-3-9/api
+              port: notebook-port


### PR DESCRIPTION
This PR Integrates the TrustyAI notebook into ODH

## Description
New files that have been added:

- `notebook-images/base/jupyter-trustyai-notebook-imagestream.yaml`
- `tests/resources/notebook-controller/notebooks/jupyter-trustyai-ubi9-python-3-9.yaml`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
Should be merged first this PR -> https://github.com/opendatahub-io/notebooks/pull/51
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
