### PR TITLE
Add dynamic namespace to delegate-url arg to OAuth

### DIFF
--- a/data-science-pipelines/overlays/ds-pipeline-ui/deployments/ds-pipeline-ui.yaml
+++ b/data-science-pipelines/overlays/ds-pipeline-ui/deployments/ds-pipeline-ui.yaml
@@ -20,6 +20,12 @@ spec:
     spec:
       containers:
         - name: oauth-proxy
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
           args:
             - --https-address=:8443
             - --provider=openshift
@@ -28,7 +34,7 @@ spec:
             - --tls-cert=/etc/tls/private/tls.crt
             - --tls-key=/etc/tls/private/tls.key
             - --cookie-secret=SECRET
-            - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "ds-pipeline-ui"}}'
+            - '--openshift-delegate-urls={"/": {"resource": "services", "verb": "get", "name": "ds-pipeline-ui", "namespace": "$(NAMESPACE)"}}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
           image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
           ports:


### PR DESCRIPTION
## Description
Fixes #757 

When attempting to authenticate to the OAuth Proxy via a service account, the request will return a 403 if the SA only has view permissions on the namespace level.

## How Has This Been Tested?
Manually deployed from github branch.  To test:

1. Install ODH with kfdef in a namespace called `opendatahub`
2. Create a test service account:
```
oc create sa test-connection
```
3. Grant permissions to the service account:
```
oc policy add-role-to-user view system:serviceaccount:opendatahub:test-connection
```
4. Verify SA has permissions to list service:
```
oc login --token=$(oc create token test-connection -n opendatahub)
oc get services ds-pipeline-ui -n opendatahub
```
5.  Attempt to authenticate to OAuth
```
URL='https://ds-pipelines-ui.route.com/apis/v1beta1/experiments' 
curl --location --request GET $URL \
--header "Authorization: Bearer $(oc create token test-connection -n opendatahub)" -I
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
