### PR TITLE
Update KF controller image to a quay image

### DIFF
--- a/odh-notebook-controller/kf-notebook-controller/overlays/openshift/kustomization.yaml
+++ b/odh-notebook-controller/kf-notebook-controller/overlays/openshift/kustomization.yaml
@@ -9,7 +9,7 @@ commonLabels:
   component.opendatahub.io/name: kf-notebook-controller
   opendatahub.io/component: "true"
 images:
-  - name: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
+  - name: docker.io/kubeflownotebookswg/notebook-controller
     newName: quay.io/opendatahub/kubeflow-notebook-controller
     newTag: v1.6.1-1
 configMapGenerator:


### PR DESCRIPTION
The replacement for kf controller image failed because kustomize was unable to find `public.ecr.aws/j1r0q0g6/notebooks/notebook-controller` value to replace .As a result, the KF controller still uses the image provided by the Kubeflow. Update the manifests to use controller image provided by `quay.io/opendatahub`

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
- Install ODH operator 1.5
- Create odh-core KfDef with uri `https://github.com/VaishnaviHire/odh-manifests/tarball/fix_kubeflow_image`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
