### PR TITLE
Add workflow to auto-add issues to the Platform Planning Project

### DIFF
--- a/.github/workflows/auto-add-to-project.yaml
+++ b/.github/workflows/auto-add-to-project.yaml
@@ -1,0 +1,14 @@
+name: Add Issues to ODH Platform Planning Project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/opendatahub-io/projects/33
+          github-token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION

## Description
This workflow adds issues created in odh-manifests to the [Platform Planning Project](https://github.com/orgs/opendatahub-io/projects/33/views/1). 

**Note** 
- This requires `GH_TOKEN` secret added to the repo.
- This adds only the issues to the project. We need to thus ensure all the PRs have corresponding issues

## How Has This Been Tested?
- To test this, create an example issue in this test [repo](https://github.com/VaishnaviHire/test-workflows)
- This uses the same workflow to add issues to the sample project

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
