### PR TITLE
Fix tag's names on notebooks imagestreams with better naming

### DIFF
--- a/notebook-images/base/jupyter-datascience-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-datascience-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images:jupyter-datascience-ubi9-python-3.9-2023a-weekly
-    name: "py3.9-v2"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/notebooks@sha256:5df71f5542d2e0161f0f4342aa9a390679d72dc6fae192fd8da1e5671b27e8d4
-    name: "py3.8-v1"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images:cuda-jupyter-minimal-ubi9-python-3.9-2023a-weekly
-    name: "py3.9-v2"
+    name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/notebooks@sha256:c13cd3410e31184986d44d36ba663ca2f2225d14e5b086b09fe221219a94b6de
-    name: "py3.8-v1"
+    name: "1.2-cuda-11.4"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-minimal-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-minimal-notebook-imagestream.yaml
@@ -23,7 +23,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images:jupyter-minimal-ubi9-python-3.9-2023a-weekly
-    name: "py3.9-v2"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -34,6 +34,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/notebooks@sha256:a138838e1c9acd7708462e420bf939e03296b97e9cf6c0aa0fd9a5d20361ab75
-    name: "py3.8-v1"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images:jupyter-pytorch-ubi9-python-3.9-2023a-weekly
-    name: "py3.9-v2"
+    name: "2023.1-cuda-11.7"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/notebooks@sha256:94c5d01b19a0f30c0ca18153c50f18317f42c224e82321ef39c43116e7184731
-    name: "py3.8-v1"
+    name: "1.2-cuda-11.4"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -22,7 +22,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/workbench-images:cuda-jupyter-tensorflow-ubi9-python-3.9-2023a-weekly
-    name: "py3.9-v2"
+    name: "2023.1-cuda-11.8"
     referencePolicy:
       type: Local
   # N-1 Version of the image
@@ -33,6 +33,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/opendatahub/notebooks@sha256:fc52e4fbc8c1c70dfa22dbfe6b0353f5165c507c125df4438fca6a3f31fe976e
-    name: "py3.8-v1"
+    name: "1.2-cuda-11.4"
     referencePolicy:
       type: Local

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: cuda-jupyter-minimal-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-gpu-notebook:py3.8-v1
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-gpu-notebook:1.2-cuda-11.4
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: cuda-jupyter-pytorch-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-pytorch-notebook:py3.8-v1
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-pytorch-notebook:1.2-cuda-11.4
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-tensorflow-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-tensorflow-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:py3.8-v1
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2-cuda-11.4
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/jupyter-datascience-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/jupyter-datascience-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: jupyter-datascience-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-datascience-notebook:py3.8-v1
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-datascience-notebook:1.2
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/jupyter-minimal-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/jupyter-minimal-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: jupyter-minimal-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-notebook:py3.8-v1
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-notebook:1.2
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:


### PR DESCRIPTION
This PR fixes the tag names on notebook versions, for better presentation on the notebooks server UI.

## Description
For example, instead of being `py3.8-v2` which doesn't provide any useful information changed to `2023.1` which is the version of the notebook (the N version for example) 

## How Has This Been Tested?

-  Deploy ODH with enabled the notebook-images
-  Login to odh-dashboard and navigate into notebooks server spawner
-  Check the version name that has been changed 

![image](https://user-images.githubusercontent.com/42587738/232709684-eb326238-0c59-46ff-b284-4c847c1e395b.png)


 
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
