### PR TITLE
Fix tests to support changes introduced by 1.5 Operator

### DIFF
--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -47,7 +47,7 @@ ENV PATH="${PATH}:$HOME/.local/bin"
 RUN cd $HOME/src/ods-ci && poetry install
     
 
-COPY setup/operatorsetup scripts/install.sh scripts/installandtest.sh $HOME/peak/
+COPY setup/operatorsetup setup/pipelines-op-setup scripts/install.sh scripts/installandtest.sh $HOME/peak/
 COPY resources $HOME/peak/operator-tests/odh-manifests/resources
 COPY util $HOME/peak/operator-tests/odh-manifests
 COPY setup/odh-core.yaml $HOME/kfdef/

--- a/tests/basictests/ds-pipelines.sh
+++ b/tests/basictests/ds-pipelines.sh
@@ -63,13 +63,7 @@ function setup_monitoring() {
 
 function test_metrics() {
     header "Checking metrics for total number of runs, should be 1 since we have spun up 1 run"
-    ## On OCP 4.11, get-token is removed
-    cluster_version=`oc get -o json clusterversion | jq '.items[0].status.desired.version' | grep "4.11" || echo ""`
-    if [[ -z $cluster_version ]]; then
-        monitoring_token=`oc sa get-token prometheus-k8s -n openshift-monitoring`
-    else
-        monitoring_token=`oc create token prometheus-k8s -n openshift-monitoring`
-    fi
+    monitoring_token=$(oc create token prometheus-k8s -n openshift-monitoring)
     os::cmd::try_until_text "oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H \"Authorization: Bearer $monitoring_token\" 'https://thanos-querier.openshift-monitoring:9091/api/v1/query?query=run_server_run_count' | jq '.data.result[0].value[1]'" "1" $odhdefaulttimeout $odhdefaultinterval
 }
 

--- a/tests/scripts/install.sh
+++ b/tests/scripts/install.sh
@@ -27,6 +27,29 @@ else
     sleep 1m
   done
 fi
+
+# Update Install Plan of opendatahub-operator to Automatic. It is set to manual if deployed in openshift-ci
+oc patch installplan $(oc get installplan -l operators.coreos.com/opendatahub-operator.openshift-operators -n openshift-operators -o jsonpath="{$.items[*].metadata.name}") \
+   --namespace openshift-operators \
+    --type merge \
+    --patch '{"spec":{"approval":"Automatic"}}'
+
+# Install OpenShift Pipelines operator irrespective of SKIP_OPERATOR_INSTALL value
+echo "Installing OpenShift Pipelines operator"
+retry=5
+while [[ $retry -gt 0 ]]; do
+  ./setup.sh -o ~/peak/pipelines-op-setup 2>&1
+  if [ $? -eq 0 ]; then
+    retry=-1
+  else
+    echo "Trying restart of marketplace community operator pod"
+    oc delete pod -n openshift-marketplace $(oc get pod -n openshift-marketplace -l marketplace.operatorSource=community-operators -o jsonpath="{$.items[*].metadata.name}")
+    sleep 3m
+  fi
+  retry=$(( retry - 1))
+  sleep 1m
+done
+
 popd
 ## Grabbing and applying the patch in the PR we are testing
 pushd ~/src/odh-manifests

--- a/tests/scripts/installandtest.sh
+++ b/tests/scripts/installandtest.sh
@@ -48,7 +48,7 @@ oc get pods -o yaml -n openshift-operators > ${ARTIFACT_DIR}/openshift-operators
 echo "Saving the events in the artifacts directory"
 oc get events --sort-by='{.lastTimestamp}' > ${ARTIFACT_DIR}/${ODHPROJECT}.events.txt
 echo "Saving the logs from the opendatahub-operator pod in the artifacts directory"
-oc logs -n openshift-operators $(oc get pods -n openshift-operators -l name=opendatahub-operator -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/opendatahub-operator.log 2> /dev/null || echo "No logs for openshift-operators/opendatahub-operator"
+oc logs -n openshift-operators $(oc get pods -n openshift-operators --field-selector=spec.serviceAccountName=opendatahub-operator-controller-manager -o jsonpath="{$.items[*].metadata.name}") > ${ARTIFACT_DIR}/opendatahub-operator.log 2> /dev/null || echo "No logs for openshift-operators/opendatahub-operator"
 
 if [ "$success" -ne 1 ]; then
     exit 1

--- a/tests/setup/odh-core.yaml
+++ b/tests/setup/odh-core.yaml
@@ -11,14 +11,6 @@ spec:
         path: odh-common
     name: odh-common
   - kustomizeConfig:
-      parameters:
-        - name: namespace
-          value: openshift-operators
-      repoRef:
-        name: manifests
-        path: openshift-pipelines/cluster
-    name: openshift-pipelines
-  - kustomizeConfig:
       repoRef:
         name: manifests
         path: odh-dashboard

--- a/tests/setup/pipelines-op-setup
+++ b/tests/setup/pipelines-op-setup
@@ -1,0 +1,1 @@
+openshift-pipelines-operator-rh latest https://github.com/tektoncd/operator


### PR DESCRIPTION

## Description
- The deployment name for the operator is updated to `opendatahub-operator-controller-manager`. Update the tests to use the new name.
- DSP Operator tests are failing because, OpenShift Pipelines Operator is being installed in the namespace other than the KfDef namespace. This is not supported, since we have added ownerreferences to KfDef

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
