### PR TITLE
Add GitHub action for synchronization of notebook controller manifests

### DIFF
--- a/.github/workflows/sync_kubeflow_manifests.yaml
+++ b/.github/workflows/sync_kubeflow_manifests.yaml
@@ -1,0 +1,27 @@
+name: Sync odh-manifests with notebook controller manifests from kubeflow
+
+on:
+  workflow_dispatch
+
+jobs:
+  kubeflow-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+      - name: Gather files from kubeflow and replace manifests 
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/odh-notebook-controller
+          svn export --force https://github.com/opendatahub-io/kubeflow/branches/v1.6-branch/components/notebook-controller/config ./kf-notebook-controller
+          svn export --force https://github.com/opendatahub-io/kubeflow/branches/v1.6-branch/components/odh-notebook-controller/config ./odh-notebook-controller
+      - name: Create pull request for sync changes
+        uses: peter-evans/create-pull-request@v4.2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: odh-kubeflow-sync
+          commit-message: Automated Change
+          title: Sync odh-manifests with odh-kubeflow notebook controller manifests
+          body: This is an automated pull request to sync odh-manifests with odh-kubeflow notebook controller manifests


### PR DESCRIPTION
Follow-up on opendatahub-io/kubeflow#93

Adds a Github action that updates notebook-controller and odh-notebook-controller manifests upon receiving a dispatch from a merge in opendatahub-io/kubeflow repository.

## How Has This Been Tested?
Not fully tested yet

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
