### PR TITLE
Add tests for DSP experiments

### DIFF
--- a/tests/basictests/dsp-operator.sh
+++ b/tests/basictests/dsp-operator.sh
@@ -101,6 +101,27 @@ function verify_pipeline_availabilty() {
     os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/pipelines | jq '.total_size'" "2" $odhdefaulttimeout $odhdefaultinterval
 }
 
+function create_experiment() {
+  header "Creating an experiment"
+
+  EXPERIMENT_ID=$((curl -s -k -H "Authorization: Bearer ${SA_TOKEN}" \
+      -H "Content-Type: application/json" \
+      -X POST "https://${ROUTE}/apis/v1beta1/experiments" \
+      -d @- << EOF
+      {
+          "name": "test-experiment",
+          "description": "This is a test experiment"
+      }
+EOF
+        ) | jq -r .id)
+  os::cmd::try_until_not_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/experiments/${EXPERIMENT_ID} | jq" "null" $odhdefaulttimeout $odhdefaultinterval
+}
+
+function verify_experiment_availabilty() {
+  header "Verify experiment exists"
+  os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/experiments | jq '.total_size'" "2" $odhdefaulttimeout $odhdefaultinterval
+}
+
 function create_run() {
     header "Creating the run from uploaded pipeline"
 
@@ -120,16 +141,51 @@ EOF
     os::cmd::try_until_not_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID} | jq '" "null" $odhdefaulttimeout $odhdefaultinterval
 }
 
+function create_experiment_run() {
+    header "Creating a run that uses the test experiment"
+    RUN_ID_EXPT=$((curl -k -H "Authorization: Bearer ${SA_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -X POST "https://${ROUTE}/apis/v1beta1/runs" \
+        -d @- << EOF
+        {
+            "name": "test-experiment-run",
+            "description": "This is a test run that uses the test experiment",
+            "pipeline_spec":{
+                "pipeline_id":"${PIPELINE_ID}"
+            },
+            "resource_references":[
+            {
+               "key":{
+                  "type":"EXPERIMENT",
+                  "id":"${EXPERIMENT_ID}"
+               },
+               "name":"Default",
+               "relationship":"OWNER"
+            }
+            ]
+        }
+EOF
+        ) | jq -r .run.id)
+    os::cmd::try_until_not_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID_EXPT} | jq '" "null" $odhdefaulttimeout $odhdefaultinterval
+}
+
 function verify_run_availabilty() {
     header "verify the run exists"
 
-    os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs | jq '.total_size'" "1" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs | jq '.total_size'" "2" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function check_run_status() {
     header "Checking run status"
 
     os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID} | jq '.run.status'" "Completed" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID_EXPT} | jq '.run.status'" "Completed" $odhdefaulttimeout $odhdefaultinterval
+}
+
+function delete_experiment() {
+  header "Deleting the experiment"
+  os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' -X DELETE https://${ROUTE}/apis/v1beta1/experiments/${EXPERIMENT_ID} | jq" "" $odhdefaulttimeout $odhdefaultinterval
+  os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/experiments/${EXPERIMENT_ID} | jq '.code'" "5" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function delete_runs() {
@@ -137,6 +193,8 @@ function delete_runs() {
 
     os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' -X DELETE https://${ROUTE}/apis/v1beta1/runs/${RUN_ID} | jq" "" $odhdefaulttimeout $odhdefaultinterval
     os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID} | jq '.code'" "5" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' -X DELETE https://${ROUTE}/apis/v1beta1/runs/${RUN_ID_EXPT} | jq" "" $odhdefaulttimeout $odhdefaultinterval
+    os::cmd::try_until_text "curl -s -k -H 'Authorization: Bearer ${SA_TOKEN}' https://${ROUTE}/apis/v1beta1/runs/${RUN_ID_EXPT} | jq '.code'" "5" $odhdefaulttimeout $odhdefaultinterval
 }
 
 function delete_pipeline() {
@@ -157,10 +215,14 @@ test_metrics
 fetch_runs
 create_pipeline
 verify_pipeline_availabilty
+create_experiment
+verify_experiment_availabilty
 create_run
+create_experiment_run
 verify_run_availabilty
 check_run_status
 delete_runs
+delete_experiment
 delete_pipeline
 
 os::test::junit::declare_suite_end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding end to end tests for the Data Science Pipelines Operator / Application that test experiments

Relevant PR: https://github.com/opendatahub-io/data-science-pipelines-operator/pull/95

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Deploy a DSPA instance
- Run the following commands:
  - `make build` -- to create the test container image
  -  `make run TESTS_REGEX=ml-pipelines`
      -  This will run the container image locally
      -  It will further apply the kfdef defined in the `kfctl_openshift.yaml` file.
      - If you have the kfdef installed already, you can run this instead:
      `make run SKIP_INSTALL=true SKIP_KFDEF_INSTALL=true`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
