### PR TITLE
jupyter pytorch python 3.8 reference non-cuda image jupyter-pytorch-u…

### DIFF
--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/notebooks
     from:
       kind: DockerImage
-      name:  quay.io/opendatahub/notebooks@sha256:fa3cfa4e5c1cfe5952e64f06e294ec5dd48fc10ec90f2866d33665f57137f381
+      name: quay.io/opendatahub/notebooks@sha256:fa3cfa4e5c1cfe5952e64f06e294ec5dd48fc10ec90f2866d33665f57137f381
     name: "py3.8-v1"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -32,7 +32,7 @@ spec:
         openshift.io/imported-from: quay.io/opendatahub/notebooks
     from:
       kind: DockerImage
-      name: quay.io/opendatahub/notebooks@sha256:94c5d01b19a0f30c0ca18153c50f18317f42c224e82321ef39c43116e7184731
+      name:  quay.io/opendatahub/notebooks@sha256:fa3cfa4e5c1cfe5952e64f06e294ec5dd48fc10ec90f2866d33665f57137f381
     name: "py3.8-v1"
     referencePolicy:
       type: Local


### PR DESCRIPTION
 following imagestream tag sha256 ref in v1.5 branch and master branch is wrong: 

https://github.com/opendatahub-io/odh-manifests/blob/v1.5/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml#L35 digest resolves to cuda-jupyter-pytorch-ubi8-python-3.8-4c8f26e, 

![Bildschirmfoto 2023-04-25 um 11 40 01](https://user-images.githubusercontent.com/21118431/234238187-8b139be4-668c-410d-a5bc-0f7a464a2887.png)

should be jupyter-pytorch-ubi8-python-3.8 (without CUDA / graphics card acceleration libraries)

![Bildschirmfoto 2023-04-25 um 11 40 47](https://user-images.githubusercontent.com/21118431/234238386-c2acfd5c-19c5-4228-a623-e71812bf7fb7.png)


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
