### PR TITLE
Move CUDA indication from the tag to annotations

### DIFF
--- a/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.5"},{"name":"Notebook","version":"6.5"}]'
         openshift.io/imported-from: quay.io/opendatahub/workbench-images
         opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: $(odh-minimal-gpu-notebook-image-n)
-    name: "2023.1-cuda-11.8"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"JupyterLab","version":"3.2"},{"name":"Notebook","version":"6.4"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
     from:
       kind: DockerImage
       name: $(odh-minimal-gpu-notebook-image-n-1)
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.7"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/opendatahub/workbench-images
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: $(odh-pytorch-gpu-notebook-image-n)
-    name: "2023.1-cuda-11.7"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-        opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
+        opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"PyTorch","version":"1.8"}]'
         opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.8"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
         openshift.io/imported-from: quay.io/opendatahub/notebooks
     from:
       kind: DockerImage
       name: $(odh-pytorch-gpu-notebook-image-n-1)
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -15,24 +15,24 @@ spec:
   tags:
   # N Version of the image
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"TensorFlow","version":"2.11"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.11"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/opendatahub/workbench-images
       opendatahub.io/workbench-image-recommended: 'true'
     from:
       kind: DockerImage
       name: $(odh-tensorflow-gpu-notebook-image-n)
-    name: "2023.1-cuda-11.8"
+    name: "2023.1"
     referencePolicy:
       type: Local
   # N-1 Version of the image
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.4"},{"name":"Python","version":"v3.8"},{"name":"TensorFlow","version":"2.7"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"TensorFlow","version":"2.7"},{"name":"Tensorboard","version":"2.6"},{"name":"Boto3","version":"1.17"},{"name":"Kafka-Python","version":"2.0"},{"name":"Matplotlib","version":"3.4"},{"name":"Numpy","version":"1.19"},{"name":"Pandas","version":"1.2"},{"name":"Scikit-learn","version":"0.24"},{"name":"Scipy","version":"1.6"}]'
       openshift.io/imported-from: quay.io/opendatahub/notebooks
     from:
       kind: DockerImage
       name: $(odh-tensorflow-gpu-notebook-image-n-1)
-    name: "1.2-cuda-11.4"
+    name: "1.2"
     referencePolicy:
       type: Local

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: cuda-jupyter-minimal-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-gpu-notebook:1.2-cuda-11.4
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-gpu-notebook:1.2
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-minimal-ubi9-python-3-9.yaml
@@ -2,15 +2,15 @@
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
-  name: cuda-jupyter-tensorflow-ubi8-python-3-8
+  name: cuda-jupyter-minimal-ubi9-python-3-9
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
 spec:
   template:
     spec:
       containers:
-        - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2
+        - name: cuda-jupyter-minimal-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-gpu-notebook:2023.1
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:
@@ -19,7 +19,7 @@ spec:
                 --ServerApp.port=8888
                 --ServerApp.token=''
                 --ServerApp.password=''
-                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8
+                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-minimal-ubi9-python-3-9
           ports:
             - name: notebook-port
               containerPort: 8888
@@ -39,5 +39,5 @@ spec:
             failureThreshold: 3
             httpGet:
               scheme: HTTP
-              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8/api
+              path: /notebook/opendatahub/cuda-jupyter-minimal-ubi9-python-3-9/api
               port: notebook-port

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi8-python-3-8.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi8-python-3-8.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: cuda-jupyter-pytorch-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-pytorch-notebook:1.2-cuda-11.4
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-pytorch-notebook:1.2
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-pytorch-ubi9-python-3-9.yaml
@@ -2,15 +2,15 @@
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
-  name: cuda-jupyter-tensorflow-ubi8-python-3-8
+  name: cuda-jupyter-pytorch-ubi9-python-3-9
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
 spec:
   template:
     spec:
       containers:
-        - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2
+        - name: cuda-jupyter-pytorch-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-pytorch-notebook:2023.1
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:
@@ -19,7 +19,7 @@ spec:
                 --ServerApp.port=8888
                 --ServerApp.token=''
                 --ServerApp.password=''
-                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8
+                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-pytorch-ubi9-python-3-9
           ports:
             - name: notebook-port
               containerPort: 8888
@@ -39,5 +39,5 @@ spec:
             failureThreshold: 3
             httpGet:
               scheme: HTTP
-              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8/api
+              path: /notebook/opendatahub/cuda-jupyter-pytorch-ubi9-python-3-9/api
               port: notebook-port

--- a/tests/resources/notebook-controller/notebooks/cuda-jupyter-tensorflow-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/cuda-jupyter-tensorflow-ubi9-python-3-9.yaml
@@ -2,15 +2,15 @@
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
-  name: cuda-jupyter-tensorflow-ubi8-python-3-8
+  name: cuda-jupyter-tensorflow-ubi9-python-3-9
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
 spec:
   template:
     spec:
       containers:
-        - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2
+        - name: cuda-jupyter-tensorflow-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:2023.1
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:
@@ -19,7 +19,7 @@ spec:
                 --ServerApp.port=8888
                 --ServerApp.token=''
                 --ServerApp.password=''
-                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8
+                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi9-python-3-9
           ports:
             - name: notebook-port
               containerPort: 8888
@@ -39,5 +39,5 @@ spec:
             failureThreshold: 3
             httpGet:
               scheme: HTTP
-              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8/api
+              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi9-python-3-9/api
               port: notebook-port

--- a/tests/resources/notebook-controller/notebooks/jupyter-datascience-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/jupyter-datascience-ubi9-python-3-9.yaml
@@ -2,15 +2,15 @@
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
-  name: cuda-jupyter-tensorflow-ubi8-python-3-8
+  name: jupyter-datascience-ubi9-python-3-9
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
 spec:
   template:
     spec:
       containers:
-        - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2
+        - name: jupyter-datascience-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-datascience-notebook:2023.1
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:
@@ -19,7 +19,7 @@ spec:
                 --ServerApp.port=8888
                 --ServerApp.token=''
                 --ServerApp.password=''
-                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8
+                --ServerApp.base_url=/notebook/opendatahub/jupyter-datascience-ubi9-python-3-9
           ports:
             - name: notebook-port
               containerPort: 8888
@@ -39,5 +39,5 @@ spec:
             failureThreshold: 3
             httpGet:
               scheme: HTTP
-              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8/api
+              path: /notebook/opendatahub/jupyter-datascience-ubi9-python-3-9/api
               port: notebook-port

--- a/tests/resources/notebook-controller/notebooks/jupyter-minimal-ubi9-python-3-9.yaml
+++ b/tests/resources/notebook-controller/notebooks/jupyter-minimal-ubi9-python-3-9.yaml
@@ -2,15 +2,15 @@
 apiVersion: kubeflow.org/v1
 kind: Notebook
 metadata:
-  name: cuda-jupyter-tensorflow-ubi8-python-3-8
+  name: jupyter-minimal-ubi9-python-3-9
   annotations:
     notebooks.opendatahub.io/inject-oauth: "true"
 spec:
   template:
     spec:
       containers:
-        - name: cuda-jupyter-tensorflow-ubi8-python-3-8
-          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-tensorflow-notebook:1.2
+        - name: jupyter-minimal-ubi9-python-3-9
+          image: image-registry.openshift-image-registry.svc:5000/opendatahub/jupyter-minimal-notebook:2023.1
           imagePullPolicy: Always
           workingDir: /opt/app-root/src
           env:
@@ -19,7 +19,7 @@ spec:
                 --ServerApp.port=8888
                 --ServerApp.token=''
                 --ServerApp.password=''
-                --ServerApp.base_url=/notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8
+                --ServerApp.base_url=/notebook/opendatahub/jupyter-minimal-ubi9-python-3-9
           ports:
             - name: notebook-port
               containerPort: 8888
@@ -39,5 +39,5 @@ spec:
             failureThreshold: 3
             httpGet:
               scheme: HTTP
-              path: /notebook/opendatahub/cuda-jupyter-tensorflow-ubi8-python-3-8/api
+              path: /notebook/opendatahub/jupyter-minimal-ubi9-python-3-9/api
               port: notebook-port


### PR DESCRIPTION
This PR includes the CUDA tag version in the annotation list of the image itself rather than the version name.

Related-to: https://github.com/opendatahub-io/notebooks/issues/101

## How Has This Been Tested?
- Deploy ODH with enabled the notebook-images
- Login to odh-dashboard and navigate into notebooks server spawner
- Check the version name that has been changed

![image](https://github.com/red-hat-data-services/odh-manifests/assets/42587738/1e3d153c-334c-48f6-bbd7-cfbe831ff86d)

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
