### PR TITLE
Update to dspo to v0.2.1.

### DIFF
--- a/data-science-pipelines-operator/base/kustomization.yaml
+++ b/data-science-pipelines-operator/base/kustomization.yaml
@@ -29,6 +29,13 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.IMAGES_ARTIFACT
+  - name: IMAGES_OAUTHPROXY
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_OAUTHPROXY
   - name: IMAGES_PERSISTENTAGENT
     objref:
       kind: ConfigMap

--- a/data-science-pipelines-operator/base/params.env
+++ b/data-science-pipelines-operator/base/params.env
@@ -1,8 +1,9 @@
-IMAGES_APISERVER=quay.io/opendatahub/ds-pipelines-api-server:main-e6b9013
-IMAGES_ARTIFACT=quay.io/opendatahub/ds-pipelines-artifact-manager:main-e6b9013
-IMAGES_PERSISTENTAGENT=quay.io/opendatahub/ds-pipelines-persistenceagent:main-e6b9013
-IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:main-e6b9013
+IMAGES_APISERVER=quay.io/opendatahub/ds-pipelines-api-server:main-ad67f6a
+IMAGES_ARTIFACT=quay.io/opendatahub/ds-pipelines-artifact-manager:main-ad67f6a
+IMAGES_PERSISTENTAGENT=quay.io/opendatahub/ds-pipelines-persistenceagent:main-ad67f6a
+IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:main-ad67f6a
 IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
 IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
-IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:v0.2.0
+IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:v0.2.1
+IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0

--- a/data-science-pipelines-operator/configmaps/files/config.yaml
+++ b/data-science-pipelines-operator/configmaps/files/config.yaml
@@ -1,6 +1,7 @@
 Images:
   ApiServer: $(IMAGES_APISERVER)
   Artifact: $(IMAGES_ARTIFACT)
+  OAuthProxy: $(IMAGES_OAUTHPROXY)
   PersistentAgent: $(IMAGES_PERSISTENTAGENT)
   ScheduledWorkflow: $(IMAGES_SCHEDULEDWORKFLOW)
   Cache: $(IMAGES_CACHE)

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -38,6 +38,8 @@ spec:
             value: $(IMAGES_APISERVER)
           - name: IMAGES_ARTIFACT
             value: $(IMAGES_ARTIFACT)
+          - name: IMAGES_OAUTHPROXY
+            value: $(IMAGES_OAUTHPROXY)
           - name: IMAGES_PERSISTENTAGENT
             value: $(IMAGES_PERSISTENTAGENT)
           - name: IMAGES_SCHEDULEDWORKFLOW


### PR DESCRIPTION
## Description
Update to dspo to v0.2.1.

## How Has This Been Tested?
with kfdef on ocp 4.12
```
spec:
  applications:
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: data-science-pipelines-operator/
      name: data-science-pipelines-operator
  repos:
    - name: manifests
      uri: 'https://github.com/HumairAK/odh-manifests/tarball/v0.2.1'
```

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
