### PR TITLE
Fix RHODS-8873

### DIFF
--- a/model-mesh/overlays/odh-model-controller/rbac/role.yaml
+++ b/model-mesh/overlays/odh-model-controller/rbac/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: manager-role
+  name: odh-model-controller-role
 rules:
 - apiGroups:
   - ""

--- a/model-mesh/overlays/odh-model-controller/rbac/role_binding.yaml
+++ b/model-mesh/overlays/odh-model-controller/rbac/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: odh-model-controller-role
 subjects:
 - kind: ServiceAccount
   name: odh-model-controller


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
odh-model-controller uses a generic name for cluster-role so there was a possibility to be overwritten by other operators.(https://issues.redhat.com/browse/RHODS-8873)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This change was added to odh-model-controller repo and it was tested by openshift-ci. odh-model-controller(https://github.com/opendatahub-io/odh-model-controller/pull/46)
**manual test way:**
~~~
kind: KfDef
apiVersion: kfdef.apps.kubeflow.org/v1
metadata:
  name: opendatahub
  namespace: opendatahub
spec:
  applications:
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: odh-common
      name: odh-common
    - kustomizeConfig:
        repoRef:
          name: manifests
          path: model-mesh
      name: model-mesh
  repos:
    - name: manifests
      uri: 'https://github.com/Jooho/odh-manifests/tarball/odh_8873'
~~~


## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
