### PR TITLE
Add new imagestreams to inlude Code-Server and R-Studio 

### DIFF
--- a/notebook-images/OWNERS
+++ b/notebook-images/OWNERS
@@ -1,7 +1,9 @@
 # Fetched from https://github.com/opendatahub-io/notebooks root OWNERS
-reviewers:
-  - atheo89
-  - VaishnaviHire
 approvers:
   - atheo89
+  - harshad16
+
+reviewers:
+  - atheo89
+  - harshad16
   - VaishnaviHire

--- a/notebook-images/base/kustomization.yaml
+++ b/notebook-images/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - jupyter-pytorch-notebook-imagestream.yaml
 - jupyter-tensorflow-notebook-imagestream.yaml
 - jupyter-trustyai-notebook-imagestream.yaml
+
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: notebooks

--- a/notebook-images/base/params.yaml
+++ b/notebook-images/base/params.yaml
@@ -43,4 +43,4 @@ varReference:
   kind: ImageStream
   apiGroup: image.openshift.io/v1
   name: odh-trustyai-notebook-image-n
-  
+

--- a/notebook-images/overlays/additional/README.md
+++ b/notebook-images/overlays/additional/README.md
@@ -7,3 +7,6 @@ The source build files for any notebook in this repo must exist under the [opend
 Notebooks:
 ===
 * [Elyra Notebook](https://github.com/opendatahub-io/s2i-lab-elyra) - Jupyter notebook image with Elyra-AI installed
+* [Code Server Notebook ](https://github.com/opendatahub-io/notebooks/tree/main/codeserver) - Notebook image, allows to run Visual Studio Code (VSCode)
+* [R Studio Notebook](https://github.com/opendatahub-io/notebooks/tree/main/rstudio) - Notebook image, integrated development environment (IDE) for R
+* [CUDA R Studio Notebook](https://github.com/opendatahub-io/notebooks/tree/main/rstudio) - Notebook image, integrated development environment (IDE) for R with embedded CUDA capabilities

--- a/notebook-images/overlays/additional/code-server-notebook-imagestream.yaml
+++ b/notebook-images/overlays/additional/code-server-notebook-imagestream.yaml
@@ -1,0 +1,25 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/codeserver"
+    opendatahub.io/notebook-image-name: "Code Server"
+    opendatahub.io/notebook-image-desc: "Code Server workbench image, allows to run Visual Studio Code (VSCode) on a remote server through the browser."
+    opendatahub.io/notebook-image-order: "7"
+  name: code-server-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"code-sever","version":"4.11"}]'
+      openshift.io/imported-from: quay.io/opendatahub/workbench-images
+    from:
+      kind: DockerImage
+      name: quay.io/opendatahub/workbench-images@sha256:fd5b9f65c0f46d4c093e2f58fce305eeb125bf19ee1d88f67b9fafe56142e92d
+    name: "2023.1"
+    referencePolicy:
+      type: Source

--- a/notebook-images/overlays/additional/kustomization.yaml
+++ b/notebook-images/overlays/additional/kustomization.yaml
@@ -4,6 +4,9 @@ bases:
 - ../../base
 resources:
 - elyra-notebook-imagestream.yaml
+- code-server-notebook-imagestream.yaml
+- rstudio-notebook-imagestream.yaml
+- rstudio-gpu-notebook-imagestream.yaml
 commonLabels:
   opendatahub.io/component: "true"
   component.opendatahub.io/name: notebooks

--- a/notebook-images/overlays/additional/rstudio-gpu-notebook-imagestream.yaml
+++ b/notebook-images/overlays/additional/rstudio-gpu-notebook-imagestream.yaml
@@ -1,0 +1,25 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
+    opendatahub.io/notebook-image-name: "CUDA - R Studio"
+    opendatahub.io/notebook-image-desc: "R Studio workbench image, allows to integrated development environment for R, a programming language for statistical computing and graphics."
+    opendatahub.io/notebook-image-order: "9"
+  name: rstudio-gpu-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
+      openshift.io/imported-from: quay.io/opendatahub/workbench-images
+    from:
+      kind: DockerImage
+      name: quay.io/opendatahub/workbench-images@sha256:aef5fd12264651abf286e9a4efbe25ca002cc257fbc6f1a5daf39fd55c7d6206
+    name: "2023.1"
+    referencePolicy:
+      type: Source

--- a/notebook-images/overlays/additional/rstudio-notebook-imagestream.yaml
+++ b/notebook-images/overlays/additional/rstudio-notebook-imagestream.yaml
@@ -1,0 +1,25 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  labels:
+    opendatahub.io/notebook-image: "true"
+  annotations:
+    opendatahub.io/notebook-image-url: "https://github.com/opendatahub-io/notebooks/tree/main/rstudio"
+    opendatahub.io/notebook-image-name: "R Studio"
+    opendatahub.io/notebook-image-desc: "R Studio workbench image, allows to integrated development environment for R, a programming language for statistical computing and graphics."
+    opendatahub.io/notebook-image-order: "8"
+  name: rstudio-notebook
+spec:
+  lookupPolicy:
+    local: true
+  tags:
+  - annotations:
+      opendatahub.io/notebook-software: '[{"name":"Python","version":"v3.9"}]'
+      opendatahub.io/notebook-python-dependencies: '[{"name":"r-studio","version":"4.3"}]'
+      openshift.io/imported-from: quay.io/opendatahub/workbench-images
+    from:
+      kind: DockerImage
+      name: quay.io/opendatahub/workbench-images@sha256:75d6764e1155c1d18dc4472ff319f9291d0d9703b19ee1374e902b6ab7f55cfb
+    name: "2023.1"
+    referencePolicy:
+      type: Source


### PR DESCRIPTION
This PR introduces the Code-Server (VS-Code) and R-Studio workbench images into OOTB. 

Related issue: https://github.com/opendatahub-io/odh-manifests/issues/843

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?

- Deploy ODH with the **additional overlay** enabled for notebook-images
```
  - kustomizeConfig:
      overlays:
      - additional
      repoRef:
        name: manifests
        path: notebook-images
    name: notebook-images
```
- Login to odh-dashboard and spawn a notebook **Code Server, R Studio or Cuda R Studio**
- Confirm that the notebook spawned successfully and its functionality works

![Screenshot from 2023-06-20 14-30-27](https://github.com/opendatahub-io/odh-manifests/assets/42587738/0689aa11-5260-43f9-ab17-d6e9cc747e38)

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
