### PR TITLE
Add dspo 1.0.0 to odh.

### DIFF
--- a/data-science-pipelines-operator/base/kustomization.yaml
+++ b/data-science-pipelines-operator/base/kustomization.yaml
@@ -71,6 +71,27 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.IMAGES_MARIADB
+  - name: IMAGES_MLMDENVOY
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDENVOY
+  - name: IMAGES_MLMDGRPC
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDGRPC
+  - name: IMAGES_MLMDWRITER
+    objref:
+      kind: ConfigMap
+      name: dspo-parameters
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.IMAGES_MLMDWRITER
   - name: IMAGES_DSPO
     objref:
       kind: ConfigMap

--- a/data-science-pipelines-operator/base/params.env
+++ b/data-science-pipelines-operator/base/params.env
@@ -1,9 +1,12 @@
-IMAGES_APISERVER=quay.io/opendatahub/ds-pipelines-api-server:main-ad67f6a
-IMAGES_ARTIFACT=quay.io/opendatahub/ds-pipelines-artifact-manager:main-ad67f6a
-IMAGES_PERSISTENTAGENT=quay.io/opendatahub/ds-pipelines-persistenceagent:main-ad67f6a
-IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:main-ad67f6a
+IMAGES_APISERVER=quay.io/opendatahub/ds-pipelines-api-server:v1.0.0
+IMAGES_ARTIFACT=quay.io/opendatahub/ds-pipelines-artifact-manager:v1.0.0
+IMAGES_PERSISTENTAGENT=quay.io/opendatahub/ds-pipelines-persistenceagent:v1.0.0
+IMAGES_SCHEDULEDWORKFLOW=quay.io/opendatahub/ds-pipelines-scheduledworkflow:v1.0.0
 IMAGES_CACHE=registry.access.redhat.com/ubi8/ubi-minimal
 IMAGES_MOVERESULTSIMAGE=registry.access.redhat.com/ubi8/ubi-micro
 IMAGES_MARIADB=registry.redhat.io/rhel8/mariadb-103:1-188
-IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:v0.2.1
+IMAGES_DSPO=quay.io/opendatahub/data-science-pipelines-operator:v1.0.0
 IMAGES_OAUTHPROXY=registry.redhat.io/openshift4/ose-oauth-proxy:v4.12.0
+IMAGES_MLMDENVOY=quay.io/opendatahub/ds-pipelines-metadata-envoy:v1.0.0
+IMAGES_MLMDGRPC=quay.io/opendatahub/ds-pipelines-metadata-grpc:v1.0.0
+IMAGES_MLMDWRITER=quay.io/opendatahub/ds-pipelines-metadata-writer:v1.0.0

--- a/data-science-pipelines-operator/configmaps/files/config.yaml
+++ b/data-science-pipelines-operator/configmaps/files/config.yaml
@@ -7,3 +7,6 @@ Images:
   Cache: $(IMAGES_CACHE)
   MoveResultsImage: $(IMAGES_MOVERESULTSIMAGE)
   MariaDB: $(IMAGES_MARIADB)
+  MlmdEnvoy: $(IMAGES_MLMDENVOY)
+  MlmdGRPC: $(IMAGES_MLMDGRPC)
+  MlmdWriter: $(IMAGES_MLMDWRITER)

--- a/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
+++ b/data-science-pipelines-operator/crd/bases/datasciencepipelinesapplications.opendatahub.io_datasciencepipelinesapplications.yaml
@@ -235,6 +235,151 @@ spec:
                         type: string
                     type: object
                 type: object
+              mlmd:
+                default:
+                  deploy: false
+                properties:
+                  deploy:
+                    default: false
+                    type: boolean
+                  envoy:
+                    properties:
+                      image:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  grpc:
+                    properties:
+                      image:
+                        type: string
+                      port:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                  writer:
+                    properties:
+                      image:
+                        type: string
+                      resources:
+                        description: ResourceRequirements structures compute resource
+                          requirements. Replaces ResourceRequirements from corev1
+                          which also includes optional storage field. We handle storage
+                          field separately, and should not include it as a subfield
+                          for Resources.
+                        properties:
+                          limits:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    required:
+                    - image
+                    type: object
+                type: object
               mlpipelineUI:
                 properties:
                   configMap:

--- a/data-science-pipelines-operator/manager/manager.yaml
+++ b/data-science-pipelines-operator/manager/manager.yaml
@@ -50,6 +50,12 @@ spec:
             value: $(IMAGES_MOVERESULTSIMAGE)
           - name: IMAGES_MARIADB
             value: $(IMAGES_MARIADB)
+          - name: IMAGES_MLMDENVOY
+            value: $(IMAGES_MLMDENVOY)
+          - name: IMAGES_MLMDGRPC
+            value: $(IMAGES_MLMDGRPC)
+          - name: IMAGES_MLMDWRITER
+            value: $(IMAGES_MLMDWRITER)
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/data-science-pipelines-operator/rbac/role.yaml
+++ b/data-science-pipelines-operator/rbac/role.yaml
@@ -229,3 +229,25 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+    - mcad.ibm.com
+  resources:
+    - appwrappers
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - delete
+- apiGroups:
+    - ray.io
+  resources:
+    - rayclusters
+    - rayjobs
+    - rayservices
+  verbs:
+    - create
+    - get
+    - list
+    - patch
+    - delete


### PR DESCRIPTION
## Description
Add dspo 1.0.0, full change set can be found here: 
https://github.com/opendatahub-io/data-science-pipelines-operator/releases

## How Has This Been Tested?
In OCP via manual deployment and live testing. Simply deploy the kfdef pointing to this fork and deploy a dspa to test out the changes.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
