### PR TITLE
Fix github token to use the default one on digest updater workflow

### DIFF
--- a/.github/workflows/notebooks-digest-updater-upstream.yaml
+++ b/.github/workflows/notebooks-digest-updater-upstream.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: [ update-n-version ]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -98,7 +98,7 @@ jobs:
         with:
           source_branch:  ${{ env.DIGEST_UPDATER_BRANCH }}
           destination_branch: ${{ env.BRANCH_NAME}}
-          github_token: ${{ secrets.GH_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_label: "automated pr"
           pr_title: "[Digest Updater Action] Update notebook's imageStreams image tag to digest format"
           pr_body: |


### PR DESCRIPTION
## Description
Fix github token to use github built-in variable, see https://docs.github.com/en/actions/security-guides/automatic-token-authentication

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
