### PR TITLE
Fix rhods-9627

### DIFF
--- a/model-mesh/base/kustomization.yaml
+++ b/model-mesh/base/kustomization.yaml
@@ -4,8 +4,6 @@ resources:
   - ../odh-modelmesh-controller/overlays/odh
   - ../odh-model-controller/overlays/odh
 
-commonLabels:
-  app.kubernetes.io/part-of: model-mesh
 namespace: opendatahub
 configMapGenerator:
   - envs:

--- a/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
+++ b/model-mesh/odh-model-controller/overlays/odh/kustomization.yaml
@@ -5,8 +5,6 @@ resources:
 
 patchesStrategicMerge:
   - odh_model_controller_manager_patch.yaml
-commonLabels:
-  app.kubernetes.io/managed-by: odh-model-controller
 
 configurations:
   - params.yaml

--- a/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
+++ b/model-mesh/odh-modelmesh-controller/overlays/odh/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
   - ./manager
 
 commonLabels:
-  app.kubernetes.io/managed-by: modelmesh-controller
+  app: model-mesh
+  app.kubernetes.io/part-of: model-mesh
 
 configurations:
   - params.yaml


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With the new manifests, it tries to use a new label to explain components but it causes an upgrade fail because the spec.selector in the deployment is immutable.

In order to upgrade properly, I rollback the labels.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

It does not impact a fresh cluster installation. I tested this with RHODS live builder image
Live Builder image:  quay.io/jooholee/rhods-operator-live-catalog:1.29.0-rhods-9627

You can test the image with the cluster that installed 1.28 RHODS

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
