### PR TITLE
fix: rewrites url on notebook logout

### DIFF
--- a/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
+++ b/service-mesh/control-plane/base/resource-templates/08_virtual-service.yaml
@@ -8,6 +8,17 @@ spec:
   hosts:
   - "opendatahub.$DOMAIN"
   http:
+  - match:
+    - uri:
+        # match host.com/notebook/ns/username/logout
+        regex: "^/notebook/.*/.*/logout"
+    route:
+    - destination:
+        host: odh-dashboard
+        port:
+          number: 80
+    rewrite:
+      uri: "/oauth/sign_out"
   - route:
     - destination:
         host: odh-dashboard


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds a rewrite rule to the dashboard VirtualService to rewrite a notebook logout request to our pre-existing logout destination. This fixes hitting the logout button from inside of notebooks started from data science project or the jupyter tile. Fixes #877.

## How Has This Been Tested?
Tested on CRC:
1. Create a data science project with a workbench defined.
2. Open it.
3. Go to File > Log Out menu 
4. Upon hitting Log Out, user is redirected to our logout endpoint, and is logged out of their session (this includes their login to the dashboard tab, as we have SSO). 

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
