### PR TITLE
Add networkpolicy for access dashboard and modelmesh monitoring

### DIFF
--- a/modelmesh-monitoring/base/kustomization.yaml
+++ b/modelmesh-monitoring/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - prometheus
 - prometheus-operator
 - servicemonitors
+- networkpolicy
 configMapGenerator:
   - name: model-monitoring-parameters
     envs:

--- a/modelmesh-monitoring/base/networkpolicy/kustomization.yaml
+++ b/modelmesh-monitoring/base/networkpolicy/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- monitoring_networkpolicy.yaml

--- a/modelmesh-monitoring/base/networkpolicy/monitoring_networkpolicy.yaml
+++ b/modelmesh-monitoring/base/networkpolicy/monitoring_networkpolicy.yaml
@@ -1,0 +1,28 @@
+# Defines ingress rules for specific port. These ports are defined by
+# the services residing in redhat-ods-monitoring. namespaceSelector
+# ensures that traffic from only the desired namespaces is allowed
+
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: opendatahub-monitoring
+spec:
+  podSelector: {}
+  ingress:
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP # blackbox
+          port: 9115
+        - protocol: TCP
+          port: 8443
+        - protocol: TCP  # prometheus
+          port: 9091
+        # - protocol: TCP  # alertmanager not needed for ODH
+        #   port: 10443
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  policyTypes:
+    - Ingress

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - image-puller.clusterrolebinding.yaml
   - model-serving-role.yaml
   - model-serving-role-binding.yaml
+  - networkpolicy.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard

--- a/odh-dashboard/base/networkpolicy.yaml
+++ b/odh-dashboard/base/networkpolicy.yaml
@@ -1,0 +1,28 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: opendatahub-applications
+spec:
+  podSelector: {}
+  ingress:
+    - ports:
+        - protocol: TCP  # dashboard 
+          port: 8443
+        # - protocol: TCP
+        #   port: 8080
+        # - protocol: TCP
+        #   port: 8081
+        # - protocol: TCP   # dsp
+        #   port: 5432
+        # - protocol: TCP   # kserve
+        #   port: 8082
+        # - protocol: TCP
+        #   port: 8099
+        # - protocol: TCP
+        #   port: 8181
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              opendatahub.io/generated-namespace: 'true'
+  policyTypes:
+    - Ingress


### PR DESCRIPTION
## Description
- new operator better to not add networkpolicy if components are not enabled. since we already apply such manifests from odh-manifests, it is better to handle in the same way.
- cherry-pick from [odh-deploy/network/](https://github.com/red-hat-data-services/odh-deployer/tree/main/network)
ref: https://github.com/opendatahub-io/opendatahub-operator/issues/423

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
