### PR TITLE
Fix software annotation to point the correct version on CUDA version (v1.7 branch)

### DIFF
--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -15,7 +15,7 @@ spec:
   tags:
   # N Version of the image
   - annotations:
-      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.7"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
+      opendatahub.io/notebook-software: '[{"name":"CUDA","version":"11.8"},{"name":"Python","version":"v3.9"},{"name":"PyTorch","version":"1.13"}]'
       opendatahub.io/notebook-python-dependencies: '[{"name":"PyTorch","version":"1.13"},{"name":"Tensorboard","version":"2.11"},{"name":"Boto3","version":"1.26"},{"name":"Kafka-Python","version":"2.0"},{"name":"Kfp-tekton","version":"1.5"},{"name":"Matplotlib","version":"3.6"},{"name":"Numpy","version":"1.24"},{"name":"Pandas","version":"1.5"},{"name":"Scikit-learn","version":"1.2"},{"name":"Scipy","version":"1.10"}]'
       openshift.io/imported-from: quay.io/opendatahub/workbench-images
       opendatahub.io/workbench-image-recommended: 'true'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR is meant to point to the correct version of the GPU.
Had to show 11.8 instead 11.7

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
