### PR TITLE
Update TrustyAI manifests to allow parameterized images

### DIFF
--- a/trustyai-service-operator/base/kustomization.yaml
+++ b/trustyai-service-operator/base/kustomization.yaml
@@ -10,4 +10,24 @@ resources:
 patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
 
+configMapGenerator:
+  - name: config
+    env: params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
 vars:
+  - name: trustyaiServiceImageName
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiServiceImageName
+  - name: trustyaiServiceImageTag
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiServiceImageTag

--- a/trustyai-service-operator/base/params.env
+++ b/trustyai-service-operator/base/params.env
@@ -1,0 +1,2 @@
+trustyaiServiceImageName=quay.io/trustyai/trustyai-service
+trustyaiServiceImageTag=v0.2.0

--- a/trustyai-service-operator/manager/kustomization.yaml
+++ b/trustyai-service-operator/manager/kustomization.yaml
@@ -6,10 +6,3 @@ images:
 - name: controller
   newName: quay.io/trustyai/trustyai-service-operator
   newTag: v1.8.0
-configMapGenerator:
-  - name: config
-    literals:
-      - trustyaiServiceImageName=quay.io/trustyai/trustyai-service
-      - trustyaiServiceImageTag=v0.2.0
-generatorOptions:
-  disableNameSuffixHash: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Allows for the specification of TrustyAI-service images via an optional parameter in the trustyai-service kfdef, if desired.  If no image values are passed, the default `quay.io/trustyai/trustyai-service:latest` is used. 



## Description
<!--- Describe your changes in detail -->
This is now possible: 
```yaml
  - kustomizeConfig:
      repoRef:
        name: manifests
        path: trustyai-service-operator
      parameters:
         - name: trustyaiServiceImageName
           value: NEW_IMAGE_NAME
        - name: trustyaiServiceImageTag
          value: NEW_IMAGE_TAG
    name: trustyai-service-operator
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
