### PR TITLE
First incubation of Dashboard

### DIFF
--- a/odh-dashboard/apps/kustomization.yaml
+++ b/odh-dashboard/apps/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
-bases:
+resources:
   - ./jupyter

--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -3,29 +3,28 @@ kind: Kustomization
 commonLabels:
   app: odh-dashboard
   app.kubernetes.io/part-of: odh-dashboard
-bases:
+resources:
   - ../apps
   - ../modelserving
-resources:
-- role.yaml
-- cluster-role.yaml
-- service-account.yaml
-- role-binding.yaml
-- cluster-role-binding.yaml
-- auth-delegator.clusterrolebinding.yaml
-- cluster-monitoring-role-binding.yaml
-- deployment.yaml
-- routes.yaml
-- service.yaml
-- oauth.secret.yaml
-- fetch-builds-and-images.rbac.yaml
-- image-puller.clusterrolebinding.yaml
-- model-serving-role.yaml
-- model-serving-role-binding.yaml
+  - role.yaml
+  - cluster-role.yaml
+  - service-account.yaml
+  - role-binding.yaml
+  - cluster-role-binding.yaml
+  - auth-delegator.clusterrolebinding.yaml
+  - cluster-monitoring-role-binding.yaml
+  - deployment.yaml
+  - routes.yaml
+  - service.yaml
+  - oauth.secret.yaml
+  - fetch-builds-and-images.rbac.yaml
+  - image-puller.clusterrolebinding.yaml
+  - model-serving-role.yaml
+  - model-serving-role-binding.yaml
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard
-  newTag: v2.12.0
+  newTag: incubation-2023-07-27
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
-  newTag: v4.8
+  newTag: v4.10

--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -122,3 +122,15 @@ rules:
       - console.openshift.io
     resources:
       - odhquickstarts
+  - apiGroups:
+      - template.openshift.io
+    verbs:
+      - '*'
+    resources:
+      - templates
+  - apiGroups:
+      - serving.kserve.io
+    verbs:
+      - '*'
+    resources:
+      - servingruntimes

--- a/odh-dashboard/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
+++ b/odh-dashboard/crd/odhapplications.dashboard.opendatahub.io.crd.yaml
@@ -116,6 +116,7 @@ spec:
                 isEnabled:
                   type: boolean
                 kfdefApplications:
+                  description: "(Deprecated) Apps do not rely on other deployments, they are deployed by those components."
                   items:
                     type: string
                   type: array

--- a/odh-dashboard/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
+++ b/odh-dashboard/crd/odhdashboardconfigs.opendatahub.io.crd.yaml
@@ -53,6 +53,10 @@ spec:
                       type: string
                     disablePipelines:
                       type: boolean
+                    disableBiasMetrics:
+                      type: boolean
+                    disablePerformanceMetrics:
+                      type: boolean
                 groupsConfig:
                   type: object
                   required:
@@ -141,6 +145,10 @@ spec:
                     storageClassName:
                       type: string
                 templateOrder:
+                  type: array
+                  items:
+                    type: string
+                templateDisablement:
                   type: array
                   items:
                     type: string

--- a/odh-dashboard/modelserving/ovms-gpu-ootb.yaml
+++ b/odh-dashboard/modelserving/ovms-gpu-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino with GPU Support Model Serving Definition'

--- a/odh-dashboard/modelserving/ovms-ootb.yaml
+++ b/odh-dashboard/modelserving/ovms-ootb.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     opendatahub.io/dashboard: 'true'
     opendatahub.io/ootb: 'true'
-    opendatahub.io/configurable: 'true'
   annotations:
     tags: 'ovms,servingruntime'
     description: 'OpenVino Model Serving Definition'
@@ -57,5 +56,5 @@ objects:
           version: '1'
         - autoSelect: true
           name: tensorflow
-          version: "2"
+          version: "2" 
 parameters: []


### PR DESCRIPTION
First release of the incubation branch in Dashboard. Using the nightly image tag (cloned).

Also includes https://github.com/opendatahub-io/odh-dashboard/releases/tag/v2.13.0