### PR TITLE
Update TrustyAI-Operator manifests to allow for parameterized images

### DIFF
--- a/trustyai-service-operator/base/kustomization.yaml
+++ b/trustyai-service-operator/base/kustomization.yaml
@@ -11,8 +11,12 @@ patchesStrategicMerge:
 - manager_auth_proxy_patch.yaml
 
 configMapGenerator:
-  - name: config
-    env: params.env
+  - env: params.env
+    name: config
+
+configurations:
+  - params.yaml
+
 generatorOptions:
   disableNameSuffixHash: true
 
@@ -31,3 +35,17 @@ vars:
       apiVersion: v1
     fieldref:
       fieldpath: data.trustyaiServiceImageTag
+  - name: trustyaiOperatorImageName
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiOperatorImageName
+  - name: trustyaiOperatorImageTag
+    objref:
+      kind: ConfigMap
+      name: config
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.trustyaiOperatorImageTag

--- a/trustyai-service-operator/base/params.env
+++ b/trustyai-service-operator/base/params.env
@@ -1,2 +1,4 @@
 trustyaiServiceImageName=quay.io/trustyai/trustyai-service
-trustyaiServiceImageTag=v0.2.0
+trustyaiServiceImageTag=latest
+trustyaiOperatorImageName=quay.io/trustyai/trustyai-service-operator
+trustyaiOperatorImageTag=latest

--- a/trustyai-service-operator/base/params.env
+++ b/trustyai-service-operator/base/params.env
@@ -1,4 +1,4 @@
 trustyaiServiceImageName=quay.io/trustyai/trustyai-service
-trustyaiServiceImageTag=latest
+trustyaiServiceImageTag=v0.2.0
 trustyaiOperatorImageName=quay.io/trustyai/trustyai-service-operator
-trustyaiOperatorImageTag=latest
+trustyaiOperatorImageTag=v1.8.0

--- a/trustyai-service-operator/base/params.yaml
+++ b/trustyai-service-operator/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+  - kind: Deployment
+    path: spec/template/spec/containers[]/image

--- a/trustyai-service-operator/manager/kustomization.yaml
+++ b/trustyai-service-operator/manager/kustomization.yaml
@@ -2,7 +2,3 @@ resources:
 - manager.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-images:
-- name: controller
-  newName: quay.io/trustyai/trustyai-service-operator
-  newTag: v1.8.0

--- a/trustyai-service-operator/manager/manager.yaml
+++ b/trustyai-service-operator/manager/manager.yaml
@@ -32,7 +32,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: $(trustyaiOperatorImageName):$(trustyaiOperatorImageTag)
         name: manager
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows for parameterized specification of operator + service images within the TrustyAI KFdef; this syncs the odh manifests with the upstream TrustyAI manifests. 


## Description
See above

## How Has This Been Tested?
Mirrors TrustyAI's upstream configuration + CI, and therefore is tested via TrustyAI CI

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
