### PR TITLE
Fix: missing kuberay imageparam variable

### DIFF
--- a/ray/operator/base/params.env
+++ b/ray/operator/base/params.env
@@ -1,1 +1,2 @@
 namespace=opendatahub
+odh-kuberay-operator-controller-image=quay.io/opendatahub/kuberay-operator:v0.5.0


### PR DESCRIPTION
## Description
change from https://github.com/zdtsw-forking/odh-manifests/blob/86c9b27600b4664f5c03c42149a95efd8cd8fadb/ray/operator/base/params.env  was missed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
