### PR TITLE
set annotations with recommended accelerators

### DIFF
--- a/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-minimal-gpu-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "CUDA"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with GPU support and minimal dependency set to start experimenting with Jupyter environment."
     opendatahub.io/notebook-image-order: "3"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-minimal-gpu-notebook
 spec:
   lookupPolicy:

--- a/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-pytorch-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "PyTorch"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with PyTorch libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "4"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-pytorch-notebook
 spec:
   lookupPolicy:

--- a/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
+++ b/notebook-images/base/jupyter-tensorflow-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "TensorFlow"
     opendatahub.io/notebook-image-desc: "Jupyter notebook image with TensorFlow libraries and dependencies to start experimenting with advanced AI/ML notebooks."
     opendatahub.io/notebook-image-order: "5"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: jupyter-tensorflow-notebook
 spec:
   lookupPolicy:

--- a/notebook-images/overlays/additional/rstudio-gpu-notebook-imagestream.yaml
+++ b/notebook-images/overlays/additional/rstudio-gpu-notebook-imagestream.yaml
@@ -8,6 +8,7 @@ metadata:
     opendatahub.io/notebook-image-name: "CUDA - R Studio"
     opendatahub.io/notebook-image-desc: "R Studio workbench image, allows to integrated development environment for R, a programming language for statistical computing and graphics."
     opendatahub.io/notebook-image-order: "9"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
   name: rstudio-gpu-notebook
 spec:
   lookupPolicy:


### PR DESCRIPTION
Annotations have been updated to include recommended accelerators for OOTB ImageStreams.

fixes [notebook#151](https://github.com/opendatahub-io/notebooks/issues/151).