### PR TITLE
2.14.1 Dashboard + Incubation

### DIFF
--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -24,7 +24,7 @@ resources:
 images:
 - name: odh-dashboard
   newName: quay.io/opendatahub/odh-dashboard
-  digest: sha256:08e85d8b4b4ef255ace46c6587e528a533da723e56c5faa63170dcbc2c2bf71c
+  digest: sha256:0e401c345f874b6c1011e93176c3f4e76efaef16c4930c521f7eed5541de1def
 - name: oauth-proxy
   newName: registry.redhat.io/openshift4/ose-oauth-proxy
   digest: sha256:ab112105ac37352a2a4916a39d6736f5db6ab4c29bad4467de8d613e80e9bb33

--- a/odh-dashboard/crd/acceleratorprofiles.opendatahub.io.crd.yaml
+++ b/odh-dashboard/crd/acceleratorprofiles.opendatahub.io.crd.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: acceleratorprofiles.dashboard.opendatahub.io
+spec:
+  group: dashboard.opendatahub.io
+  scope: Namespaced
+  names:
+    plural: acceleratorprofiles
+    singular: acceleratorprofile
+    kind: AcceleratorProfile
+  versions:
+    - name: v1alpha
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - displayName
+                - enabled
+                - identifier
+              properties:
+                displayName:
+                  type: string
+                enabled:
+                  type: boolean
+                identifier:
+                  type: string
+                description:
+                  type: string
+                tolerations:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - key
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      value:
+                        type: string
+                      effect:
+                        type: string
+                      tolerationSeconds:
+                        type: integer
+   

--- a/odh-dashboard/crd/kustomization.yaml
+++ b/odh-dashboard/crd/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - odhquickstarts.console.openshift.io.crd.yaml
 - odhdocuments.dashboard.opendatahub.io.crd.yaml
 - odhapplications.dashboard.opendatahub.io.crd.yaml
+- acceleratorprofiles.opendatahub.io.crd.yaml

--- a/odh-dashboard/kfdef/README.md
+++ b/odh-dashboard/kfdef/README.md
@@ -1,6 +1,6 @@
 # Dashboard
 
-The Open Data Hub Dashboard component installs a UI which 
+The Open Data Hub Dashboard component installs a UI which:
 
 - Shows what's installed
 - Show's what's available for installation
@@ -9,13 +9,16 @@ The Open Data Hub Dashboard component installs a UI which
 
 For more information, visit the project [GitHub repo](https://github.com/opendatahub-io/odh-dashboard).
 
-### Folders
+## Folders
+
 1. base: contains all the necessary yaml files to install the dashboard
 1. manifests/overlays/odhdashboardconfig: **OPTIONAL** overlay to deploy an ODHDashboardConfig with the odh-dashboard application.  This is only required if you want to deploy configuration outside of the default ODHDashboardConfigs that will be initialized at runtime
 
-##### Installation with KFDef
+### Installation with KFDef
+
 You can deploy the dashboard using the [odh-dashboard-kfnbc-test.yaml](odh-dashboard-kfnbc-test.yaml)
-```
+
+```yaml
   - kustomizeConfig:
       repoRef:
         name: manifests
@@ -23,15 +26,27 @@ You can deploy the dashboard using the [odh-dashboard-kfnbc-test.yaml](odh-dashb
     name: odh-dashboard
 ```
 
-
 If you would like to deploy the default configs for the Dashboard groups and `ODHDashboardConfig` you can enable the `odhdashboardconfig` overlay.
 NOTE: If you deploy this with the odh-operator, you will need to allow the operator to deploy the initial version of the files and then remove the `odhdashboardconfig` from the overlay to prevent the operator from reseting any changes made to the groups or config
-```
+
+```yaml
   - kustomizeConfig:
       overlays:
         - odhdashboardconfig
       repoRef:
         name: manifests
         path: odh-dashboard
+    name: odh-dashboard
+```
+
+If you would want to test the incubation version of the dashboard, you can enable the `incubation` overlay.
+
+```yaml
+  - kustomizeConfig:
+      overlays:
+        - incubation
+      repoRef:
+        name: manifests
+        path: manifests
     name: odh-dashboard
 ```


### PR DESCRIPTION
Version 2.14.1 release + incubation.

This will include new Habana work once the image is finish building. It runs over night.

Release Notes for 2.14.1: https://github.com/opendatahub-io/odh-dashboard/releases/tag/v2.14.1

Current features in Incubation: https://github.com/orgs/opendatahub-io/projects/24/views/31