### PR TITLE
TrustyAI CI: Update to MLServer 1.x

### DIFF
--- a/tests/basictests/trustyai.sh
+++ b/tests/basictests/trustyai.sh
@@ -33,12 +33,12 @@ function deploy_model() {
     os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/modelmesh/service_account.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
     oc label namespace $MM_NAMESPACE "modelmesh-enabled=true" --overwrite=true || echo "Failed to apply modelmesh-enabled label."
     os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/secret.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
-    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/odh-mlserver-0.x.yaml  -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/odh-mlserver-1.x.yaml  -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
 
     SECRETKEY=$(openssl rand -hex 32)
     sed -i "s/<secretkey>/$SECRETKEY/g" ${RESOURCEDIR}/trustyai/sample-minio.yaml || eval "$FAILURE_HANDLING"
     os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/sample-minio.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
-    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/openvino-inference-service.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
+    os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/minio_sklearn_mlserver_model.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
     os::cmd::expect_success "oc apply -f ${RESOURCEDIR}/trustyai/trustyai_crd.yaml -n ${MM_NAMESPACE}" || eval "$FAILURE_HANDLING"
 }
 
@@ -98,7 +98,7 @@ function schedule_and_check_request(){
         \"modelId\": \"example-sklearn-isvc\",
         \"protectedAttribute\": \"predict-0\",
         \"favorableOutcome\": 0,
-        \"outcomeName\": \"predict\",
+        \"outcomeName\": \"predict-0\",
         \"privilegedAttribute\": 0.0,
         \"unprivilegedAttribute\": 1.0
     }'" "requestId" || eval "$FAILURE_HANDLING"
@@ -140,7 +140,7 @@ function teardown_trustyai_test() {
   fi
 
   os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/secret.yaml" || eval "$FAILURE_HANDLING"
-  os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/odh-mlserver-0.x.yaml" || eval "$FAILURE_HANDLING"
+  os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/odh-mlserver-1.x.yaml" || eval "$FAILURE_HANDLING"
   os::cmd::expect_success "oc delete -f ${RESOURCEDIR}/trustyai/trustyai_crd.yaml"  || eval "$FAILURE_HANDLING"
   os::cmd::expect_success "oc delete project $MM_NAMESPACE" || eval "$FAILURE_HANDLING"
 }

--- a/tests/resources/trustyai/minio_sklearn_mlserver_model.yaml
+++ b/tests/resources/trustyai/minio_sklearn_mlserver_model.yaml
@@ -22,7 +22,7 @@ spec:
     model:
       modelFormat:
         name: sklearn
-      runtime: mlserver-0.x
+      runtime: mlserver-1.x
       storage:
         key: aws-connection-minio-data-connection
         path: sklearn/model.joblib

--- a/tests/resources/trustyai/odh-mlserver-1.x.yaml
+++ b/tests/resources/trustyai/odh-mlserver-1.x.yaml
@@ -1,24 +1,11 @@
-# Copyright 2021 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 apiVersion: serving.kserve.io/v1alpha1
 kind: ServingRuntime
 metadata:
-  name: mlserver-0.x
+  name: mlserver-1.x
   annotations:
     enable-route: "true"
   labels:
-    name: modelmesh-serving-mlserver-0.x-SR
+    name: modelmesh-serving-mlserver-1.x-SR
 spec:
   supportedModelFormats:
     - name: sklearn
@@ -40,7 +27,7 @@ spec:
 
   containers:
     - name: mlserver
-      image: quay.io/opendatahub/mlserver:0.5.2
+      image: seldonio/mlserver:1.3.2
       env:
         - name: MLSERVER_MODELS_DIR
           value: "/models/_mlserver_models/"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
MM update to v0.11 removed support for the 0.x mlserver, so this PR bumps the mlserver version in the TrustyAI CI tests accordingly

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
Matches upstream CI

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
