### PR TITLE
Update manifest to support generic route

### DIFF
--- a/kserve/base/inferenceservice-config-patch.yaml
+++ b/kserve/base/inferenceservice-config-patch.yaml
@@ -24,7 +24,7 @@ data:
         "ingressClassName" : "istio",
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "https",
-        "disableIstioVirtualHost": true
+        "disableIstioVirtualHost": false
     }
   logger: |-
     {

--- a/model-mesh/odh-model-controller/rbac/role.yaml
+++ b/model-mesh/odh-model-controller/rbac/role.yaml
@@ -2,214 +2,213 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: odh-model-controller-role
 rules:
 - apiGroups:
-    - ""
+  - ""
   resources:
-    - configmaps
-    - endpoints
-    - namespaces
-    - pods
-    - secrets
-    - serviceaccounts
-    - services
+  - configmaps
+  - endpoints
+  - namespaces
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
   verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshcontrolplanes
+  - servicemeshcontrolplanes
   verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - use
-    - watch
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - use
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmemberrolls
+  - servicemeshmemberrolls
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmembers
+  - servicemeshmembers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmembers/finalizers
+  - servicemeshmembers/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - monitoring.coreos.com
+  - monitoring.coreos.com
   resources:
-    - podmonitors
-    - servicemonitors
+  - podmonitors
+  - servicemonitors
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - virtualservices
+  - virtualservices
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - virtualservices/finalizers
+  - virtualservices/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.k8s.io
+  - networking.k8s.io
   resources:
-    - networkpolicies
+  - networkpolicies
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - rbac.authorization.k8s.io
+  - rbac.authorization.k8s.io
   resources:
-    - clusterrolebindings
-    - rolebindings
+  - clusterrolebindings
+  - rolebindings
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - route.openshift.io
+  - route.openshift.io
   resources:
-    - routes
+  - routes
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - route.openshift.io
+  - route.openshift.io
   resources:
-    - routes/custom-host
+  - routes/custom-host
   verbs:
-    - create
+  - create
 - apiGroups:
-    - security.istio.io
+  - security.istio.io
   resources:
-    - peerauthentications
+  - peerauthentications
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - inferenceservices
+  - inferenceservices
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - inferenceservices/finalizers
+  - inferenceservices/finalizers
   verbs:
-    - get
-    - list
-    - update
-    - watch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - servingruntimes
+  - servingruntimes
   verbs:
-    - create
-    - get
-    - list
-    - update
-    - watch
+  - create
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - servingruntimes/finalizers
+  - servingruntimes/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - telemetry.istio.io
+  - telemetry.istio.io
   resources:
-    - telemetries
+  - telemetries
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/model-mesh/odh-model-controller/rbac/role.yaml
+++ b/model-mesh/odh-model-controller/rbac/role.yaml
@@ -2,206 +2,214 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: odh-model-controller-role
 rules:
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - configmaps
-  - endpoints
-  - namespaces
-  - pods
-  - secrets
-  - serviceaccounts
-  - services
+    - configmaps
+    - endpoints
+    - namespaces
+    - pods
+    - secrets
+    - serviceaccounts
+    - services
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshcontrolplanes
+    - servicemeshcontrolplanes
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - use
-  - watch
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - use
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmemberrolls
+    - servicemeshmemberrolls
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmembers
+    - servicemeshmembers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmembers/finalizers
+    - servicemeshmembers/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - monitoring.coreos.com
+    - monitoring.coreos.com
   resources:
-  - podmonitors
-  - servicemonitors
+    - podmonitors
+    - servicemonitors
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.istio.io
+    - networking.istio.io
   resources:
-  - virtualservices
+    - virtualservices
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.istio.io
+    - networking.istio.io
   resources:
-  - virtualservices/finalizers
+    - virtualservices/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.k8s.io
+    - networking.k8s.io
   resources:
-  - networkpolicies
+    - networkpolicies
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - rbac.authorization.k8s.io
+    - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
-  - rolebindings
+    - clusterrolebindings
+    - rolebindings
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - route.openshift.io
+    - route.openshift.io
   resources:
-  - routes
+    - routes
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - security.istio.io
+    - route.openshift.io
   resources:
-  - peerauthentications
+    - routes/custom-host
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
 - apiGroups:
-  - serving.kserve.io
+    - security.istio.io
   resources:
-  - inferenceservices
+    - peerauthentications
   verbs:
-  - get
-  - list
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - inferenceservices/finalizers
+    - inferenceservices
   verbs:
-  - get
-  - list
-  - update
-  - watch
+    - get
+    - list
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - servingruntimes
+    - inferenceservices/finalizers
   verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
+    - get
+    - list
+    - update
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - servingruntimes/finalizers
+    - servingruntimes
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - get
+    - list
+    - update
+    - watch
 - apiGroups:
-  - telemetry.istio.io
+    - serving.kserve.io
   resources:
-  - telemetries
+    - servingruntimes/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - telemetry.istio.io
+  resources:
+    - telemetries
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch

--- a/odh-model-controller/rbac/role.yaml
+++ b/odh-model-controller/rbac/role.yaml
@@ -2,214 +2,213 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: odh-model-controller-role
 rules:
 - apiGroups:
-    - ""
+  - ""
   resources:
-    - configmaps
-    - endpoints
-    - namespaces
-    - pods
-    - secrets
-    - serviceaccounts
-    - services
+  - configmaps
+  - endpoints
+  - namespaces
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
   verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshcontrolplanes
+  - servicemeshcontrolplanes
   verbs:
-    - create
-    - get
-    - list
-    - patch
-    - update
-    - use
-    - watch
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - use
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmemberrolls
+  - servicemeshmemberrolls
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmembers
+  - servicemeshmembers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - maistra.io
+  - maistra.io
   resources:
-    - servicemeshmembers/finalizers
+  - servicemeshmembers/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - monitoring.coreos.com
+  - monitoring.coreos.com
   resources:
-    - podmonitors
-    - servicemonitors
+  - podmonitors
+  - servicemonitors
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - virtualservices
+  - virtualservices
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.istio.io
+  - networking.istio.io
   resources:
-    - virtualservices/finalizers
+  - virtualservices/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - networking.k8s.io
+  - networking.k8s.io
   resources:
-    - networkpolicies
+  - networkpolicies
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - rbac.authorization.k8s.io
+  - rbac.authorization.k8s.io
   resources:
-    - clusterrolebindings
-    - rolebindings
+  - clusterrolebindings
+  - rolebindings
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - route.openshift.io
+  - route.openshift.io
   resources:
-    - routes
+  - routes
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - route.openshift.io
+  - route.openshift.io
   resources:
-    - routes/custom-host
+  - routes/custom-host
   verbs:
-    - create
+  - create
 - apiGroups:
-    - security.istio.io
+  - security.istio.io
   resources:
-    - peerauthentications
+  - peerauthentications
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - inferenceservices
+  - inferenceservices
   verbs:
-    - get
-    - list
-    - watch
+  - get
+  - list
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - inferenceservices/finalizers
+  - inferenceservices/finalizers
   verbs:
-    - get
-    - list
-    - update
-    - watch
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - servingruntimes
+  - servingruntimes
   verbs:
-    - create
-    - get
-    - list
-    - update
-    - watch
+  - create
+  - get
+  - list
+  - update
+  - watch
 - apiGroups:
-    - serving.kserve.io
+  - serving.kserve.io
   resources:
-    - servingruntimes/finalizers
+  - servingruntimes/finalizers
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
-    - telemetry.istio.io
+  - telemetry.istio.io
   resources:
-    - telemetries
+  - telemetries
   verbs:
-    - create
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/odh-model-controller/rbac/role.yaml
+++ b/odh-model-controller/rbac/role.yaml
@@ -2,206 +2,214 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  creationTimestamp: null
   name: odh-model-controller-role
 rules:
 - apiGroups:
-  - ""
+    - ""
   resources:
-  - configmaps
-  - endpoints
-  - namespaces
-  - pods
-  - secrets
-  - serviceaccounts
-  - services
+    - configmaps
+    - endpoints
+    - namespaces
+    - pods
+    - secrets
+    - serviceaccounts
+    - services
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshcontrolplanes
+    - servicemeshcontrolplanes
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - use
-  - watch
+    - create
+    - get
+    - list
+    - patch
+    - update
+    - use
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmemberrolls
+    - servicemeshmemberrolls
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmembers
+    - servicemeshmembers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - maistra.io
+    - maistra.io
   resources:
-  - servicemeshmembers/finalizers
+    - servicemeshmembers/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - monitoring.coreos.com
+    - monitoring.coreos.com
   resources:
-  - podmonitors
-  - servicemonitors
+    - podmonitors
+    - servicemonitors
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.istio.io
+    - networking.istio.io
   resources:
-  - virtualservices
+    - virtualservices
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.istio.io
+    - networking.istio.io
   resources:
-  - virtualservices/finalizers
+    - virtualservices/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - networking.k8s.io
+    - networking.k8s.io
   resources:
-  - networkpolicies
+    - networkpolicies
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - rbac.authorization.k8s.io
+    - rbac.authorization.k8s.io
   resources:
-  - clusterrolebindings
-  - rolebindings
+    - clusterrolebindings
+    - rolebindings
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - route.openshift.io
+    - route.openshift.io
   resources:
-  - routes
+    - routes
   verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - security.istio.io
+    - route.openshift.io
   resources:
-  - peerauthentications
+    - routes/custom-host
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
 - apiGroups:
-  - serving.kserve.io
+    - security.istio.io
   resources:
-  - inferenceservices
+    - peerauthentications
   verbs:
-  - get
-  - list
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - inferenceservices/finalizers
+    - inferenceservices
   verbs:
-  - get
-  - list
-  - update
-  - watch
+    - get
+    - list
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - servingruntimes
+    - inferenceservices/finalizers
   verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
+    - get
+    - list
+    - update
+    - watch
 - apiGroups:
-  - serving.kserve.io
+    - serving.kserve.io
   resources:
-  - servingruntimes/finalizers
+    - servingruntimes
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - get
+    - list
+    - update
+    - watch
 - apiGroups:
-  - telemetry.istio.io
+    - serving.kserve.io
   resources:
-  - telemetries
+    - servingruntimes/finalizers
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - telemetry.istio.io
+  resources:
+    - telemetries
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
With opendatahub-io/odh-model-controller#59 we had implemented a hot fix by exposing predictor URL directly to user but to provide proper fix we need to implement a generic openshift route for kserve inference service.

Now with opendatahub-io/odh-model-controller#84 we had implemented the generic route functionality so I am resetting the disableIstioVirtualHost: false


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
